### PR TITLE
feat: Add wasm support to net_diagnostics

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.wasm32-unknown-unknown]
+runner = "wasm-bindgen-test-runner"
+# rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,2 @@
 [target.wasm32-unknown-unknown]
 runner = "wasm-bindgen-test-runner"
-# rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,6 +147,7 @@ jobs:
         run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
         env:
           RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG' }}
+          IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
 
   check_semver:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
     name: CI Test Suite
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
     uses: "./.github/workflows/tests.yaml"
+    secrets: inherit
 
   cross_build:
     name: Cross Build Only

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -47,6 +47,7 @@ jobs:
     with:
       flaky: true
       git-ref: ${{ inputs.branch }}
+    secrets: inherit
   notify:
     needs: tests
     if: ${{ always() }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,15 +6,15 @@ on:
   workflow_call:
     inputs:
       rust-version:
-        description: 'The version of the rust compiler to run'
+        description: "The version of the rust compiler to run"
         type: string
-        default: 'stable'
+        default: "stable"
       flaky:
-        description: 'Whether to also run flaky tests'
+        description: "Whether to also run flaky tests"
         type: boolean
         default: false
       git-ref:
-        description: 'Which git ref to checkout'
+        description: "Which git ref to checkout"
         type: string
         default: ${{ github.ref }}
 
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [ubuntu-latest, macOS-arm-latest]
-        rust: [ '${{ inputs.rust-version }}' ]
+        rust: ["${{ inputs.rust-version }}"]
         features: [all, none, default]
         include:
           - name: ubuntu-latest
@@ -53,91 +53,91 @@ jobs:
       # not SCCACHE_GHA_ENABLED.
       RUSTC_WRAPPER: "sccache"
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ inputs.git-ref }}
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.git-ref }}
 
-    - name: Install ${{ matrix.rust }} rust
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ matrix.rust }}
+      - name: Install ${{ matrix.rust }} rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
 
-    - name: Install cargo-nextest
-      uses: taiki-e/install-action@v2
-      with:
-        tool: nextest@0.9.80
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.80
 
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
 
-    - name: Select features
-      run: |
-        case "${{ matrix.features }}" in
-            all)
-                echo "FEATURES=--all-features" >> "$GITHUB_ENV"
-                ;;
-            none)
-                echo "FEATURES=--no-default-features" >> "$GITHUB_ENV"
-                ;;
-            default)
-                echo "FEATURES=" >> "$GITHUB_ENV"
-                ;;
-            *)
-                exit 1
-        esac
+      - name: Select features
+        run: |
+          case "${{ matrix.features }}" in
+              all)
+                  echo "FEATURES=--all-features" >> "$GITHUB_ENV"
+                  ;;
+              none)
+                  echo "FEATURES=--no-default-features" >> "$GITHUB_ENV"
+                  ;;
+              default)
+                  echo "FEATURES=" >> "$GITHUB_ENV"
+                  ;;
+              *)
+                  exit 1
+          esac
 
-    - name: check features
-      if: ${{ ! inputs.flaky }}
-      run: |
-        for i in ${CRATES_LIST//,/ }
-        do
-          echo "Checking $i $FEATURES"
-          if [ $i = "iroh-cli" ]; then
-            targets="--bins"
+      - name: check features
+        if: ${{ ! inputs.flaky }}
+        run: |
+          for i in ${CRATES_LIST//,/ }
+          do
+            echo "Checking $i $FEATURES"
+            if [ $i = "iroh-cli" ]; then
+              targets="--bins"
+            else
+              targets="--lib --bins"
+            fi
+            echo cargo check -p $i $FEATURES $targets
+            cargo check -p $i $FEATURES $targets
+          done
+        env:
+          RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+
+      - name: build tests
+        run: |
+          cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
+
+      - name: list ignored tests
+        run: |
+          cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
+
+      - name: run tests
+        run: |
+          mkdir -p output
+          cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        env:
+          RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+          NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+
+      - name: upload results
+        if: ${{ failure() && inputs.flaky }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+          path: output
+          retention-days: 45
+          compression-level: 0
+
+      - name: doctests
+        if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}
+        run: |
+          if [ -n "${{ runner.debug }}" ]; then
+              export RUST_LOG=TRACE
           else
-            targets="--lib --bins"
+              export RUST_LOG=DEBUG
           fi
-          echo cargo check -p $i $FEATURES $targets
-          cargo check -p $i $FEATURES $targets
-        done
-      env:
-        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
-
-    - name: build tests
-      run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
-
-    - name: list ignored tests
-      run: |
-        cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
-
-    - name: run tests
-      run: |
-        mkdir -p output
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-      env:
-        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
-        NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
-
-    - name: upload results
-      if: ${{ failure() && inputs.flaky }}
-      uses: actions/upload-artifact@v7
-      with:
-        name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-        path: output
-        retention-days: 45
-        compression-level: 0
-
-    - name: doctests
-      if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}
-      run: |
-        if [ -n "${{ runner.debug }}" ]; then
-            export RUST_LOG=TRACE
-        else
-            export RUST_LOG=DEBUG
-        fi
-        cargo test --workspace --all-features --doc
+          cargo test --workspace --all-features --doc
 
   build_and_test_windows:
     timeout-minutes: 30
@@ -147,7 +147,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [windows-latest]
-        rust: [ '${{ inputs.rust-version}}' ]
+        rust: ["${{ inputs.rust-version}}"]
         features: [all, none, default]
         target:
           - x86_64-pc-windows-msvc
@@ -160,82 +160,79 @@ jobs:
       # not SCCACHE_GHA_ENABLED.
       RUSTC_WRAPPER: "sccache"
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ inputs.git-ref }}
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.git-ref }}
 
-    - name: Install ${{ matrix.rust }}
-      run: |
-        rustup toolchain install ${{ matrix.rust }}
-        rustup toolchain default ${{ matrix.rust }}
-        rustup target add ${{ matrix.target }}
-        rustup set default-host ${{ matrix.target }}
+      - name: Install ${{ matrix.rust }}
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup toolchain default ${{ matrix.rust }}
+          rustup target add ${{ matrix.target }}
+          rustup set default-host ${{ matrix.target }}
 
-    - name: Install cargo-nextest
-      shell: powershell
-      run: |
-        $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
-        Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
-        $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
-        $tmp | Expand-Archive -DestinationPath $outputDir -Force
-        $tmp | Remove-Item
+      - name: Install cargo-nextest
+        shell: powershell
+        run: |
+          $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
+          Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
+          $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
+          $tmp | Expand-Archive -DestinationPath $outputDir -Force
+          $tmp | Remove-Item
 
-    - name: Select features
-      run: |
-        switch ("${{ matrix.features }}") {
-            "all" {
-                echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            "none" {
-                echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            "default" {
-                echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            }
-            default {
-                Exit 1
-            }
-        }
+      - name: Select features
+        run: |
+          switch ("${{ matrix.features }}") {
+              "all" {
+                  echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+              }
+              "none" {
+                  echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+              }
+              "default" {
+                  echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+              }
+              default {
+                  Exit 1
+              }
+          }
 
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
 
-    - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@v2
 
-    - name: build tests
-      run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+      - name: build tests
+        run: |
+          cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
 
-    - name: list ignored tests
-      run: |
-        cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
+      - name: list ignored tests
+        run: |
+          cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
 
-    - name: tests
-      run: |
-        mkdir -p output
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-      env:
-        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
-        NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+      - name: tests
+        run: |
+          mkdir -p output
+          cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        env:
+          RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+          NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
-    - name: upload results
-      if: ${{ failure() && inputs.flaky }}
-      uses: actions/upload-artifact@v7
-      with:
-        name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-        path: output
-        retention-days: 1
-        compression-level: 0
+      - name: upload results
+        if: ${{ failure() && inputs.flaky }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+          path: output
+          retention-days: 1
+          compression-level: 0
 
   wasm_test:
     name: Build & test wasm32 for browsers
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
-      # Using self-hosted runners so use local cache for sccache and
-      # not SCCACHE_GHA_ENABLED.
-      RUSTC_WRAPPER: 'sccache'
       IROH_SERVICE_API_SECRET: ${{ secrets.IROH_SERVICE_API_SECRET }}
     steps:
       - name: Checkout sources

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,7 +52,6 @@ jobs:
       # Using self-hosted runners so use local cache for sccache and
       # not SCCACHE_GHA_ENABLED.
       RUSTC_WRAPPER: "sccache"
-      IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -120,6 +119,7 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+        IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
 
     - name: upload results
       if: ${{ failure() && inputs.flaky }}
@@ -160,7 +160,6 @@ jobs:
       # Using self-hosted runners so use local cache for sccache and
       # not SCCACHE_GHA_ENABLED.
       RUSTC_WRAPPER: "sccache"
-      IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -220,6 +219,7 @@ jobs:
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+        IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
 
     - name: upload results
       if: ${{ failure() && inputs.flaky }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,15 +6,15 @@ on:
   workflow_call:
     inputs:
       rust-version:
-        description: "The version of the rust compiler to run"
+        description: 'The version of the rust compiler to run'
         type: string
-        default: "stable"
+        default: 'stable'
       flaky:
-        description: "Whether to also run flaky tests"
+        description: 'Whether to also run flaky tests'
         type: boolean
         default: false
       git-ref:
-        description: "Which git ref to checkout"
+        description: 'Which git ref to checkout'
         type: string
         default: ${{ github.ref }}
 
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [ubuntu-latest, macOS-arm-latest]
-        rust: ["${{ inputs.rust-version }}"]
+        rust: [ '${{ inputs.rust-version }}' ]
         features: [all, none, default]
         include:
           - name: ubuntu-latest
@@ -53,91 +53,91 @@ jobs:
       # not SCCACHE_GHA_ENABLED.
       RUSTC_WRAPPER: "sccache"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.git-ref }}
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.git-ref }}
 
-      - name: Install ${{ matrix.rust }} rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
+    - name: Install ${{ matrix.rust }} rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
 
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: nextest@0.9.80
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: nextest@0.9.80
 
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Select features
-        run: |
-          case "${{ matrix.features }}" in
-              all)
-                  echo "FEATURES=--all-features" >> "$GITHUB_ENV"
-                  ;;
-              none)
-                  echo "FEATURES=--no-default-features" >> "$GITHUB_ENV"
-                  ;;
-              default)
-                  echo "FEATURES=" >> "$GITHUB_ENV"
-                  ;;
-              *)
-                  exit 1
-          esac
+    - name: Select features
+      run: |
+        case "${{ matrix.features }}" in
+            all)
+                echo "FEATURES=--all-features" >> "$GITHUB_ENV"
+                ;;
+            none)
+                echo "FEATURES=--no-default-features" >> "$GITHUB_ENV"
+                ;;
+            default)
+                echo "FEATURES=" >> "$GITHUB_ENV"
+                ;;
+            *)
+                exit 1
+        esac
 
-      - name: check features
-        if: ${{ ! inputs.flaky }}
-        run: |
-          for i in ${CRATES_LIST//,/ }
-          do
-            echo "Checking $i $FEATURES"
-            if [ $i = "iroh-cli" ]; then
-              targets="--bins"
-            else
-              targets="--lib --bins"
-            fi
-            echo cargo check -p $i $FEATURES $targets
-            cargo check -p $i $FEATURES $targets
-          done
-        env:
-          RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
-
-      - name: build tests
-        run: |
-          cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
-
-      - name: list ignored tests
-        run: |
-          cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
-
-      - name: run tests
-        run: |
-          mkdir -p output
-          cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-        env:
-          RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
-          NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
-
-      - name: upload results
-        if: ${{ failure() && inputs.flaky }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-          path: output
-          retention-days: 45
-          compression-level: 0
-
-      - name: doctests
-        if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}
-        run: |
-          if [ -n "${{ runner.debug }}" ]; then
-              export RUST_LOG=TRACE
+    - name: check features
+      if: ${{ ! inputs.flaky }}
+      run: |
+        for i in ${CRATES_LIST//,/ }
+        do
+          echo "Checking $i $FEATURES"
+          if [ $i = "iroh-cli" ]; then
+            targets="--bins"
           else
-              export RUST_LOG=DEBUG
+            targets="--lib --bins"
           fi
-          cargo test --workspace --all-features --doc
+          echo cargo check -p $i $FEATURES $targets
+          cargo check -p $i $FEATURES $targets
+        done
+      env:
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+
+    - name: build tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
+
+    - name: list ignored tests
+      run: |
+        cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
+
+    - name: run tests
+      run: |
+        mkdir -p output
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+      env:
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+        NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+
+    - name: upload results
+      if: ${{ failure() && inputs.flaky }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        path: output
+        retention-days: 45
+        compression-level: 0
+
+    - name: doctests
+      if: ${{ (! inputs.flaky) &&  matrix.features == 'all' }}
+      run: |
+        if [ -n "${{ runner.debug }}" ]; then
+            export RUST_LOG=TRACE
+        else
+            export RUST_LOG=DEBUG
+        fi
+        cargo test --workspace --all-features --doc
 
   build_and_test_windows:
     timeout-minutes: 30
@@ -147,7 +147,7 @@ jobs:
       fail-fast: false
       matrix:
         name: [windows-latest]
-        rust: ["${{ inputs.rust-version}}"]
+        rust: [ '${{ inputs.rust-version}}' ]
         features: [all, none, default]
         target:
           - x86_64-pc-windows-msvc
@@ -160,70 +160,70 @@ jobs:
       # not SCCACHE_GHA_ENABLED.
       RUSTC_WRAPPER: "sccache"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.git-ref }}
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.git-ref }}
 
-      - name: Install ${{ matrix.rust }}
-        run: |
-          rustup toolchain install ${{ matrix.rust }}
-          rustup toolchain default ${{ matrix.rust }}
-          rustup target add ${{ matrix.target }}
-          rustup set default-host ${{ matrix.target }}
+    - name: Install ${{ matrix.rust }}
+      run: |
+        rustup toolchain install ${{ matrix.rust }}
+        rustup toolchain default ${{ matrix.rust }}
+        rustup target add ${{ matrix.target }}
+        rustup set default-host ${{ matrix.target }}
 
-      - name: Install cargo-nextest
-        shell: powershell
-        run: |
-          $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
-          Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
-          $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
-          $tmp | Expand-Archive -DestinationPath $outputDir -Force
-          $tmp | Remove-Item
+    - name: Install cargo-nextest
+      shell: powershell
+      run: |
+        $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
+        Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
+        $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "~/.cargo/bin" }
+        $tmp | Expand-Archive -DestinationPath $outputDir -Force
+        $tmp | Remove-Item
 
-      - name: Select features
-        run: |
-          switch ("${{ matrix.features }}") {
-              "all" {
-                  echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-              }
-              "none" {
-                  echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-              }
-              "default" {
-                  echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-              }
-              default {
-                  Exit 1
-              }
-          }
+    - name: Select features
+      run: |
+        switch ("${{ matrix.features }}") {
+            "all" {
+                echo "FEATURES=--all-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "none" {
+                echo "FEATURES=--no-default-features" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            "default" {
+                echo "FEATURES=" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            }
+            default {
+                Exit 1
+            }
+        }
 
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
 
-      - uses: msys2/setup-msys2@v2
+    - uses: msys2/setup-msys2@v2
 
-      - name: build tests
-        run: |
-          cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+    - name: build tests
+      run: |
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
 
-      - name: list ignored tests
-        run: |
-          cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
+    - name: list ignored tests
+      run: |
+        cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
 
-      - name: tests
-        run: |
-          mkdir -p output
-          cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-        env:
-          RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
-          NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+    - name: tests
+      run: |
+        mkdir -p output
+        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+      env:
+        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+        NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
-      - name: upload results
-        if: ${{ failure() && inputs.flaky }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
-          path: output
-          retention-days: 1
-          compression-level: 0
+    - name: upload results
+      if: ${{ failure() && inputs.flaky }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        path: output
+        retention-days: 1
+        compression-level: 0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -227,33 +227,3 @@ jobs:
           path: output
           retention-days: 1
           compression-level: 0
-
-  wasm_test:
-    name: Build & test wasm32 for browsers
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    env:
-      IROH_SERVICE_API_SECRET: ${{ secrets.IROH_SERVICE_API_SECRET }}
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v6
-
-      - name: Setup node.js version 26 # need at least version 22.5 for running iroh
-        uses: actions/setup-node@v6
-        with:
-          node-version: 26
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Add wasm target
-        run: rustup target add wasm32-unknown-unknown
-
-      - name: Install wasm-bindgen-test-runner
-        uses: taiki-e/install-action@v2
-        with:
-          # Match the version of wasm-bindgen used in Cargo.lock
-          tool: wasm-bindgen-cli@0.2.125
-
-      - name: Run integration test in wasm
-        run: cargo test --test integration --target=wasm32-unknown-unknown

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,8 +107,6 @@ jobs:
     - name: build tests
       run: |
         cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
-      env:
-        IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
 
     - name: list ignored tests
       run: |
@@ -209,8 +207,6 @@ jobs:
     - name: build tests
       run: |
         cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
-      env:
-        IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
 
     - name: list ignored tests
       run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,6 +52,7 @@ jobs:
       # Using self-hosted runners so use local cache for sccache and
       # not SCCACHE_GHA_ENABLED.
       RUSTC_WRAPPER: "sccache"
+      IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -159,6 +160,7 @@ jobs:
       # Using self-hosted runners so use local cache for sccache and
       # not SCCACHE_GHA_ENABLED.
       RUSTC_WRAPPER: "sccache"
+      IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -227,3 +227,36 @@ jobs:
         path: output
         retention-days: 1
         compression-level: 0
+
+  wasm_test:
+    name: Build & test wasm32 for browsers
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    env:
+      # Using self-hosted runners so use local cache for sccache and
+      # not SCCACHE_GHA_ENABLED.
+      RUSTC_WRAPPER: 'sccache'
+      IROH_SERVICE_API_SECRET: ${{ secrets.IROH_SERVICE_API_SECRET }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Setup node.js version 26 # need at least version 22.5 for running iroh
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add wasm target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Install wasm-bindgen-test-runner
+        uses: taiki-e/install-action@v2
+        with:
+          # Match the version of wasm-bindgen used in Cargo.lock
+          tool: wasm-bindgen-cli@0.2.125
+
+      - name: Run integration test in wasm
+        run: cargo test --test integration --target=wasm32-unknown-unknown

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,6 +107,8 @@ jobs:
     - name: build tests
       run: |
         cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
+      env:
+        IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
 
     - name: list ignored tests
       run: |
@@ -207,6 +209,8 @@ jobs:
     - name: build tests
       run: |
         cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+      env:
+        IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
 
     - name: list ignored tests
       run: |

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -14,6 +14,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
+      RUST_BACKTRACE: 1
       IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
     steps:
       - name: Checkout sources

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
-      RUST_BACKTRACE: 1
+      RUST_LOG: iroh_services=trace
       IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
     steps:
       - name: Checkout sources

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -12,7 +12,7 @@ jobs:
   wasm_test:
     name: Build & test wasm32 for browsers
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
-      IROH_SERVICE_API_SECRET: ${{ secrets.IROH_SERVICE_API_SECRET }}
+      IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -9,19 +9,20 @@ on:
       - main
 
 jobs:
-  wasm_check:
-    name: Build & check wasm32 for browsers
+  wasm_test:
+    name: Build & test wasm32 for browsers
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
+      IROH_SERVICE_API_SECRET: ${{ secrets.IROH_SERVICE_API_SECRET }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
 
-      - name: Setup node.js version 22.5 # needed for browser-like websocket API support in node.js
+      - name: Setup node.js version 26 # need at least version 22.5 for running iroh
         uses: actions/setup-node@v6
         with:
-          node-version: 22.5
+          node-version: 26
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -29,20 +30,11 @@ jobs:
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown
 
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-
       - name: Install wasm-bindgen-test-runner
-        run: cargo binstall wasm-bindgen-cli --locked --no-confirm
+        uses: taiki-e/install-action@v2
+        with:
+          # Match the version of wasm-bindgen used in Cargo.lock
+          tool: wasm-bindgen-cli@0.2.125
 
-      - name: Install wasm-tools
-        uses: bytecodealliance/actions/wasm-tools/setup@v1
-
-      - name: wasm32 build
-        run: cargo build --target wasm32-unknown-unknown --no-default-features
-
-      # If the Wasm file contains any 'import "env"' declarations, then
-      # some non-Wasm-compatible code made it into the final code.
-      - name: Ensure no 'import "env"' in Wasm
-        run: |
-          ! wasm-tools print --skeleton target/wasm32-unknown-unknown/debug/iroh_services.wasm | grep 'import "env"'
+      - name: Run integration test in wasm
+        run: cargo test --test integration --target=wasm32-unknown-unknown

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -13,9 +13,6 @@ jobs:
     name: Build & test wasm32 for browsers
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    env:
-      RUST_LOG: iroh_services=trace
-      IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -39,3 +36,6 @@ jobs:
 
       - name: Run integration test in wasm
         run: cargo test --test integration --target=wasm32-unknown-unknown
+        env:
+          RUST_LOG: iroh_services=trace
+          IROH_SERVICES_API_SECRET: ${{ secrets.IROH_SERVICES_API_SECRET }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1728,7 @@ dependencies = [
  "base64",
  "built",
  "bytes",
+ "cfg_aliases",
  "data-encoding",
  "derive_more",
  "ed25519-dalek",
@@ -1747,6 +1754,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -1924,6 +1932,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2008,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2057,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
 dependencies = [
+ "anyhow",
  "n0-error-macros",
  "spez",
 ]
@@ -2323,6 +2348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2464,6 +2490,12 @@ dependencies = [
  "critical-section",
  "portable-atomic",
 ]
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -4015,6 +4047,45 @@ checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16931d57bcdd6a0dcc11254bdd1388827690c1b6807f0d2836f59a4f9eb30ac"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fccaddcb2cd722baa7453b4c3d2cb2a3071597bb91f7a4373e8775bdb151778c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3746ad029217960123cf2ebf939dda51eb931ba9f8f09c117e39c820b96aa794"
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,15 +40,16 @@ futures-buffered = "0.2.12"
 postcard = { version = "1.1.3", features = ["use-std"] }
 rand = "0.10.1"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 base64 = "0.22"
 portmapper = "0.19"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [build-dependencies]
 built = { version = "0.8", features = ["cargo-lock"] }
+cfg_aliases = "0.2.1"
 
 [dev-dependencies]
 rand = { version = "0.10", features = ["chacha"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,14 @@ cfg_aliases = "0.2.1"
 
 [dev-dependencies]
 rand = { version = "0.10", features = ["chacha"] }
+n0-error = { version = "1.0.0", features = ["anyhow"] }
+
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 temp_env_vars = "0.2.1"
 tokio = { version = "1.45", features = ["macros", "rt", "rt-multi-thread", "signal"] }
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test = "0.3.75"
 
 
 [features]
@@ -62,3 +68,7 @@ default = []
 
 [[example]]
 name = "net_diagnostics"
+
+[[test]]
+name = "integration"
+path = "tests/integration.rs"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[build.env]
+passthrough = [
+    "RUST_LOG",
+    "IROH_SERVICES_API_SECRET",
+]

--- a/build.rs
+++ b/build.rs
@@ -6,4 +6,10 @@ fn main() {
         // Convenience aliases
         wasm_browser: { all(target_family = "wasm", target_os = "unknown") },
     }
+
+    // Make the TARGET env variable available at compile time
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
 }

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,9 @@
 fn main() {
     built::write_built_file().expect("Failed to acquire build-time information");
+
+    // Setup cfg aliases
+    cfg_aliases::cfg_aliases! {
+        // Convenience aliases
+        wasm_browser: { all(target_family = "wasm", target_os = "unknown") },
+    }
 }

--- a/src/api_secret.rs
+++ b/src/api_secret.rs
@@ -96,6 +96,9 @@ impl ApiSecret {
     /// Read an Api Secret from a given environment variable
     pub fn from_env_var(env_var: &str) -> anyhow::Result<Self> {
         match std::env::var(env_var) {
+            Ok(ticket_string) if ticket_string.is_empty() => {
+                Err(anyhow!("{env_var} environment variable is set but empty"))
+            }
             Ok(ticket_string) => Self::from_str(&ticket_string)
                 .context(format!("invalid api secret at env var {env_var}")),
             Err(VarError::NotPresent) => Err(anyhow!("{env_var} environment variable is not set")),

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -294,7 +294,7 @@ impl<C: Capability + Ord> Capability for CapSet<C> {
 
 /// Create an rcan token for the api access from a PEM-encoded OpenSSH ed25519
 /// private key.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(wasm_browser))]
 pub fn create_api_token_from_openssh_pem(
     pem: &str,
     local_id: EndpointId,

--- a/src/client.rs
+++ b/src/client.rs
@@ -162,14 +162,14 @@ impl ClientBuilder {
     /// Loads the private ssh key from the given path, and creates the needed capability.
     ///
     /// The file must contain an unencrypted PEM-encoded OpenSSH ed25519 private key.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(wasm_browser))]
     pub async fn ssh_key_from_file<P: AsRef<std::path::Path>>(self, path: P) -> Result<Self> {
         let file_content = tokio::fs::read_to_string(path).await?;
         self.ssh_key(&file_content)
     }
 
     /// Creates the capability from the provided PEM-encoded OpenSSH ed25519 private key.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(wasm_browser))]
     pub fn ssh_key(mut self, pem: &str) -> Result<Self> {
         let local_id = self.endpoint.id();
         let rcan = crate::caps::create_api_token_from_openssh_pem(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 
 mod client;
 mod client_host;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(wasm_browser))]
 mod openssh;
 
 pub mod api_secret;

--- a/src/net_diagnostics.rs
+++ b/src/net_diagnostics.rs
@@ -76,7 +76,7 @@ pub mod checks {
         let direct_addrs: Vec<SocketAddr> = addr.ip_addrs().copied().collect();
 
         // 4. Port mapping probe (the one thing NetReport doesn't include)
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(wasm_browser))]
         let portmap_probe =
             match n0_future::time::timeout(Duration::from_secs(5), probe_port_mapping()).await {
                 Ok(Ok(p)) => Some(p),
@@ -92,7 +92,7 @@ pub mod checks {
 
         // TODO: setting `portmap_probe` to `None` makes svc fail to parse the report.
         // Should be fixed there, but this works too for now.
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(wasm_browser)]
         let portmap_probe = Some(PortMapProbe {
             upnp: false,
             pcp: false,
@@ -109,7 +109,7 @@ pub mod checks {
         })
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(wasm_browser))]
     async fn probe_port_mapping() -> Result<PortMapProbe> {
         let config = portmapper::Config {
             enable_upnp: true,

--- a/src/net_diagnostics.rs
+++ b/src/net_diagnostics.rs
@@ -90,8 +90,15 @@ pub mod checks {
                     None
                 }
             };
+
+        // TODO: setting `portmap_probe` to `None` makes svc fail to parse the report.
+        // Should be fixed there, but this works too for now.
         #[cfg(target_arch = "wasm32")]
-        let portmap_probe = None;
+        let portmap_probe = Some(PortMapProbe {
+            upnp: false,
+            pcp: false,
+            nat_pmp: false,
+        });
 
         Ok(DiagnosticsReport {
             endpoint_id,

--- a/src/net_diagnostics.rs
+++ b/src/net_diagnostics.rs
@@ -35,10 +35,9 @@ pub struct PortMapProbe {
 pub mod checks {
     use std::net::SocketAddr;
 
-    use n0_future::time::Duration;
-
     use anyhow::Result;
     use iroh::{Endpoint, Watcher};
+    use n0_future::time::Duration;
 
     use super::*;
 

--- a/src/net_diagnostics.rs
+++ b/src/net_diagnostics.rs
@@ -33,7 +33,9 @@ pub struct PortMapProbe {
 }
 
 pub mod checks {
-    use std::{net::SocketAddr, time::Duration};
+    use std::net::SocketAddr;
+
+    use n0_future::time::Duration;
 
     use anyhow::Result;
     use iroh::{Endpoint, Watcher};
@@ -53,7 +55,7 @@ pub mod checks {
         let endpoint_id = endpoint.id();
 
         // 1. Wait for relay connection
-        if tokio::time::timeout(timeout, endpoint.online())
+        if n0_future::time::timeout(timeout, endpoint.online())
             .await
             .is_err()
         {
@@ -62,7 +64,7 @@ pub mod checks {
 
         // 2. Net report (includes relay latencies and UDP connectivity)
         let mut watcher = endpoint.net_report();
-        let net_report = match tokio::time::timeout(timeout, watcher.initialized()).await {
+        let net_report = match n0_future::time::timeout(timeout, watcher.initialized()).await {
             Ok(report) => Some(report),
             Err(_) => {
                 tracing::warn!("net report timed out after {timeout:?}, using partial data");
@@ -77,7 +79,7 @@ pub mod checks {
         // 4. Port mapping probe (the one thing NetReport doesn't include)
         #[cfg(not(target_arch = "wasm32"))]
         let portmap_probe =
-            match tokio::time::timeout(Duration::from_secs(5), probe_port_mapping()).await {
+            match n0_future::time::timeout(Duration::from_secs(5), probe_port_mapping()).await {
                 Ok(Ok(p)) => Some(p),
                 Ok(Err(e)) => {
                     tracing::warn!("portmap probe failed: {e}");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use iroh::{Endpoint, protocol::Router};
+use iroh::{Endpoint, RelayMode, address_lookup::PkarrResolver, protocol::Router};
 #[cfg(not(wasm_browser))]
 use iroh_services::API_SECRET_ENV_VAR_NAME;
 use iroh_services::{ApiSecret, Client, caps::NetDiagnosticsCap, preset};
@@ -26,7 +26,18 @@ async fn main_integration_test() -> Result {
     let secret = ApiSecret::from_env_var(API_SECRET_ENV_VAR_NAME)?;
 
     let preset = preset().api_secret(secret.clone()).build()?;
-    let endpoint = Endpoint::bind(preset).await?;
+    let endpoint = Endpoint::builder(preset)
+        // force production relays to overwrite IROH_FORCE_STAGING_RELAYS from the workflow,
+        // because our API secret is for production iroh-services, which is connected to
+        // production iroh relays.
+        .relay_mode(RelayMode::Custom(iroh::defaults::prod::default_relay_map()))
+        .address_lookup(PkarrResolver::builder(
+            iroh::address_lookup::pkarr::N0_DNS_PKARR_RELAY_PROD
+                .parse()
+                .anyerr()?,
+        ))
+        .bind()
+        .await?;
     let services = Client::builder(&endpoint)
         .api_secret(secret.clone())?
         .name(format!("iroh-services integration-rs {}", env!("TARGET")))?

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,59 @@
+use std::str::FromStr;
+
+use iroh::{Endpoint, protocol::Router};
+use iroh_services::{ApiSecret, Client, caps::NetDiagnosticsCap, preset};
+use n0_error::{Result, StdResultExt};
+
+#[cfg(not(wasm_browser))]
+use tokio::test;
+#[cfg(wasm_browser)]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[test]
+async fn main_integration_test() -> Result {
+    let secret = ApiSecret::from_str(env!("IROH_SERVICES_API_SECRET"))?;
+
+    let preset = preset().api_secret(secret.clone()).build()?;
+    let endpoint = Endpoint::bind(preset).await?;
+    let services = Client::builder(&endpoint)
+        .api_secret(secret.clone())?
+        .name(format!("iroh-services integration-rs {}", env!("TARGET")))?
+        .build()
+        .await
+        .std_context("failed building iroh-services client")?;
+
+    services
+        .grant_capability(secret.addr().id, vec![NetDiagnosticsCap::GetAny])
+        .await
+        .std_context("failed granting net diagnostics capability")?;
+
+    let host = iroh_services::ClientHost::new(&endpoint);
+
+    let router = Router::builder(endpoint.clone())
+        .accept(iroh_services::CLIENT_HOST_ALPN, host)
+        .spawn();
+
+    endpoint.online().await;
+
+    services
+        .ping()
+        .await
+        .std_context("iroh-services ping failed")?;
+
+    services
+        .push_metrics()
+        .await
+        .std_context("iroh-services metrics upload failed")?;
+
+    services
+        .net_diagnostics(true)
+        .await
+        .std_context("iroh-services net diagnostics with upload failed")?;
+
+    router
+        .shutdown()
+        .await
+        .std_context("failed to shutdown endpoint")?; // will also shut down the endpoint
+
+    Ok(())
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,11 +6,17 @@ use n0_error::{Result, StdResultExt};
 
 #[cfg(not(wasm_browser))]
 use tokio::test;
+use tracing_subscriber::EnvFilter;
 #[cfg(wasm_browser)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
 async fn main_integration_test() -> Result {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_str(env!("RUST_LOG")).anyerr()?)
+        .without_time()
+        .init();
+
     let secret = ApiSecret::from_str(env!("IROH_SERVICES_API_SECRET"))?;
 
     let preset = preset().api_secret(secret.clone()).build()?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,7 +3,6 @@ use std::str::FromStr;
 use iroh::{Endpoint, protocol::Router};
 use iroh_services::{ApiSecret, Client, caps::NetDiagnosticsCap, preset};
 use n0_error::{Result, StdResultExt};
-
 #[cfg(not(wasm_browser))]
 use tokio::test;
 use tracing_subscriber::EnvFilter;
@@ -12,12 +11,17 @@ use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
 async fn main_integration_test() -> Result {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_str(env!("RUST_LOG")).anyerr()?)
-        .without_time()
-        .init();
+    if let Some(env) = option_env!("RUST_LOG") {
+        tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_str(env).anyerr()?)
+            .without_time()
+            .init();
+    }
 
-    let secret = ApiSecret::from_str(env!("IROH_SERVICES_API_SECRET"))?;
+    let Some(secret) = option_env!("IROH_SERVICES_API_SECRET") else {
+        n0_error::bail_any!("Missing IROH_SERVICES_API_SECRET env var");
+    };
+    let secret = ApiSecret::from_str(secret)?;
 
     let preset = preset().api_secret(secret.clone()).build()?;
     let endpoint = Endpoint::bind(preset).await?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,8 @@
 use std::str::FromStr;
 
 use iroh::{Endpoint, protocol::Router};
+#[cfg(not(wasm_browser))]
+use iroh_services::API_SECRET_ENV_VAR_NAME;
 use iroh_services::{ApiSecret, Client, caps::NetDiagnosticsCap, preset};
 use n0_error::{Result, StdResultExt};
 #[cfg(not(wasm_browser))]
@@ -18,10 +20,10 @@ async fn main_integration_test() -> Result {
             .init();
     }
 
-    let Some(secret) = option_env!("IROH_SERVICES_API_SECRET") else {
-        n0_error::bail_any!("Missing IROH_SERVICES_API_SECRET env var");
-    };
-    let secret = ApiSecret::from_str(secret)?;
+    #[cfg(wasm_browser)]
+    let secret = ApiSecret::from_str(option_env!("IROH_SERVICES_API_SECRET").unwrap())?;
+    #[cfg(not(wasm_browser))]
+    let secret = ApiSecret::from_env_var(API_SECRET_ENV_VAR_NAME)?;
 
     let preset = preset().api_secret(secret.clone()).build()?;
     let endpoint = Endpoint::bind(preset).await?;


### PR DESCRIPTION
## Description

Switches some `std::time`/`tokio::time` use over to `n0-future` to enable Wasm support.

Also adds an integration test that runs against the n0/dogfood project in production both natively and from node.js with Wasm (via wasm_bindgen_test) to ensure Wasm support stays working.

For that, I added an IROH_SERVICES_API_SECRETS github action secret to this repo and need to pass it through to the test in various ways, thus all the changes to workflow files.

## Breaking Changes

None


## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
