### PR TITLE
examples: Allow to configure the relays example from environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,7 +162,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -124,7 +174,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -135,7 +185,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -368,6 +418,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +471,12 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -560,7 +656,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -584,7 +680,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -595,7 +691,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -621,7 +717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -673,7 +769,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -683,7 +779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -705,7 +801,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -745,7 +841,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -812,7 +908,7 @@ checksum = "3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -958,7 +1054,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1671,7 +1767,19 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "iroh-ping"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf244919aee860f6f2455909a5eaabcaf71ed7840892a1414758ab09f817ccc"
+dependencies = [
+ "anyhow",
+ "iroh",
+ "iroh-metrics",
+ "n0-error",
 ]
 
 [[package]]
@@ -1729,6 +1837,7 @@ dependencies = [
  "built",
  "bytes",
  "cfg_aliases",
+ "clap",
  "data-encoding",
  "derive_more",
  "ed25519-dalek",
@@ -1736,6 +1845,7 @@ dependencies = [
  "getrandom 0.4.2",
  "iroh",
  "iroh-metrics",
+ "iroh-ping",
  "iroh-tickets",
  "irpc",
  "irpc-iroh",
@@ -1801,7 +1911,7 @@ checksum = "35c254013736de16472140d26904e6ac98e8f3887284dcf4af40f88c77411b56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1821,6 +1931,12 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -1871,7 +1987,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1899,7 +2015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2070,7 +2186,7 @@ checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2370,7 +2486,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2492,6 +2608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,7 +2728,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2710,7 +2832,7 @@ checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2746,7 +2868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3163,7 +3285,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3307,7 +3429,7 @@ checksum = "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3365,7 +3487,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3379,6 +3501,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3402,7 +3535,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3448,7 +3581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86e3381d9dcf425c55c450a365adb18de503f2a946f13eb05eb0402b53482484"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3477,7 +3610,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3488,7 +3621,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3582,7 +3715,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3769,7 +3902,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3888,6 +4021,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -4035,7 +4174,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4078,7 +4217,7 @@ checksum = "fccaddcb2cd722baa7453b4c3d2cb2a3071597bb91f7a4373e8775bdb151778c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4262,7 +4401,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4273,7 +4412,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4529,7 +4668,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4545,7 +4684,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4689,7 +4828,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4710,7 +4849,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4731,7 +4870,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4764,7 +4903,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ cfg_aliases = "0.2.1"
 [dev-dependencies]
 rand = { version = "0.10", features = ["chacha"] }
 n0-error = { version = "1.0.0", features = ["anyhow"] }
+iroh-ping = "1.0.0"
+clap = { version = "4.6.4", features = ["derive"] }
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 temp_env_vars = "0.2.1"

--- a/examples/relays.rs
+++ b/examples/relays.rs
@@ -9,14 +9,97 @@
 //! Your app will use only one of these methods, depending on your use case. To test this
 //! example with custom relay URLS, you will need to comment out the secret key preset
 //! example and use the `relays` method instead, pasting in your own relay URLs.
-use std::str::FromStr;
+use std::{
+    str::FromStr,
+    time::{Duration, Instant},
+};
 
-use anyhow::Context;
+use anyhow::{Context, Result};
 use clap::Parser;
 use data_encoding::HEXLOWER;
 use iroh::{Endpoint, EndpointId, RelayMap, RelayUrl, SecretKey, protocol::Router};
 
-fn relay_map_from_env() -> anyhow::Result<Option<RelayMap>> {
+#[derive(Debug, clap::Parser)]
+struct Cli {
+    targets: Vec<EndpointId>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let cli = Cli::parse();
+
+    let preset = iroh_services::preset()
+        // Read the endpoint secret key from IROH_SECRET, or create if unset.
+        .secret_key(secret_key_from_env()?)
+        // Read the relay map from IROH_RELAYS, or use default public relays if unset.
+        .relay_map(relay_map_from_env()?)
+        // Read the iroh-services API secret from IROH_SERVICES_API_SECRET.
+        .api_secret_from_env()?
+        .build()?;
+
+    // Once the preset is built, we'll pass it to the endpoint for binding.
+    // We clone the preset so we can reuse to get a client builder below.
+    let endpoint = Endpoint::builder(preset.clone()).bind().await?;
+
+    // Wait for the endpoint to be online, to prove we have an authorized
+    // connection to a relay
+    endpoint.online().await;
+    println!("endpoint id: {}", endpoint.id());
+
+    // We create a router to accept ping requests.
+    let router = Router::builder(endpoint.clone())
+        .accept(iroh_ping::ALPN, iroh_ping::Ping::default())
+        .spawn();
+
+    // A services client is not required to use, but the preset has a convenience method
+    // for creating a client builder that uses the same access token as the
+    // endpoint, so you don't need to pass the secret key separately:
+    let client = preset.client_builder(&endpoint).build().await?;
+    // We can also ping the service just to confirm everything is working
+    tokio::task::spawn(async move {
+        loop {
+            let start = Instant::now();
+            match client.ping().await {
+                Ok(_) => println!("Pinged iroh services: OK, RTT {:?}", start.elapsed()),
+                Err(err) => println!("Failed to ping iroh services: {err:#}"),
+            }
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+    });
+
+    // Ping each target in a loop.
+    for target in cli.targets {
+        let endpoint = endpoint.clone();
+        tokio::task::spawn(async move {
+            loop {
+                let start = Instant::now();
+                match iroh_ping::Ping::new().ping(&endpoint, target.into()).await {
+                    Ok(_) => println!(
+                        "Pinged {}: OK, RTT {:?})",
+                        target.fmt_short(),
+                        start.elapsed()
+                    ),
+                    Err(err) => {
+                        println!("Failed to ping {}: {err:#}", target.fmt_short());
+                        break;
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        });
+    }
+
+    println!("Waiting for Ctrl+C...");
+    tokio::signal::ctrl_c().await?;
+
+    router.shutdown().await?;
+
+    Ok(())
+}
+
+fn relay_map_from_env() -> Result<RelayMap> {
     match std::env::var("IROH_RELAYS") {
         Ok(value) if !value.is_empty() => {
             let parts = value.split(",");
@@ -28,82 +111,33 @@ fn relay_map_from_env() -> anyhow::Result<Option<RelayMap>> {
                     .with_context(|| "Failed to parse string as relay URL: {url_string}")?;
                 urls.push(url);
             }
-            Ok(Some(RelayMap::from_iter(urls)))
+            println!(
+                "Using custom relay map:\n    - {}",
+                urls.iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("\n   - ")
+            );
+            Ok(RelayMap::from_iter(urls))
         }
-        _ => Ok(None),
+        _ => {
+            println!("Using default relay map");
+            Ok(iroh::defaults::prod::default_relay_map())
+        }
     }
 }
 
-#[derive(Debug, clap::Parser)]
-struct Cli {
-    targets: Vec<EndpointId>,
-}
-
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
-
-    let cli = Cli::parse();
-
-    // Create secret key if not set.
-    let secret_key = match std::env::var("IROH_SECRET") {
+fn secret_key_from_env() -> Result<SecretKey> {
+    Ok(match std::env::var("IROH_SECRET") {
         Ok(s) => SecretKey::from_str(&s)
             .context("Failed to parse IROH_SECRET environment variable as iroh secret key")?,
         Err(_) => {
-            let s = SecretKey::generate();
+            let secret_key = SecretKey::generate();
             println!(
                 "Generated a new endpoint secret. To reuse, set\n\tIROH_SECRET={}",
-                HEXLOWER.encode(&s.to_bytes())
+                HEXLOWER.encode(&secret_key.to_bytes())
             );
-            s
+            secret_key
         }
-    };
-
-    let relay_map = relay_map_from_env()?.context("Missing IROH_RELAYS environment variable")?;
-
-    let preset = iroh_services::preset()
-        .secret_key(secret_key)
-        .relay_map(relay_map)
-        .api_secret_from_env()?
-        .build()?;
-
-    // once a preset is built, we'll pass it to the endpoint for binding.
-    // we clone the preset so we can reuse to get a client builder below
-    let endpoint = Endpoint::builder(preset.clone()).bind().await?;
-
-    // wait for the endpoint to be online, to prove we have an authorized
-    // connection to a relay
-    endpoint.online().await;
-
-    // a client is not required to use, but the preset has a convenience method
-    // for creating a client builder that uses the same access token as the
-    // endpoint, so you don't need to pass the secret key separately:
-    let client = preset.client_builder(&endpoint).build().await?;
-
-    println!("endpoint id: {}", endpoint.id());
-    let router = Router::builder(endpoint)
-        .accept(iroh_ping::ALPN, iroh_ping::Ping::default())
-        .spawn();
-
-    // we can also ping the service just to confirm everything is working
-    tokio::task::spawn(async move {
-        let res = client.ping().await;
-        println!("Pinged iroh services: {res:?}");
-    });
-
-    for target in cli.targets {
-        println!("ping {target}...");
-        let res = iroh_ping::Ping::new()
-            .ping(router.endpoint(), target.into())
-            .await;
-        println!("ping {target}: {res:?}");
-    }
-
-    // keep the connection alive
-    println!("waiting for ctrl+c...");
-    tokio::signal::ctrl_c().await?;
-
-    router.shutdown().await?;
-
-    Ok(())
+    })
 }

--- a/examples/relays.rs
+++ b/examples/relays.rs
@@ -49,7 +49,7 @@ use std::{
 use anyhow::{Context, Result};
 use clap::Parser;
 use data_encoding::HEXLOWER;
-use iroh::{Endpoint, EndpointId, RelayMap, RelayUrl, SecretKey, Watcher, protocol::Router};
+use iroh::{Endpoint, EndpointId, RelayMap, RelayUrl, SecretKey, protocol::Router};
 
 /// Bind an iroh services endpoint and ping the given targets over iroh-ping.
 #[derive(Debug, clap::Parser)]
@@ -147,7 +147,7 @@ fn relay_map_from_env() -> Result<RelayMap> {
                 let url: RelayUrl = url_string
                     .trim()
                     .parse()
-                    .with_context(|| "Failed to parse string as relay URL: {url_string}")?;
+                    .with_context(|| format!("Failed to parse string as relay URL: {url_string}"))?;
                 urls.push(url);
             }
             println!(

--- a/examples/relays.rs
+++ b/examples/relays.rs
@@ -9,50 +9,67 @@
 //! Your app will use only one of these methods, depending on your use case. To test this
 //! example with custom relay URLS, you will need to comment out the secret key preset
 //! example and use the `relays` method instead, pasting in your own relay URLs.
-use iroh::Endpoint;
+use std::str::FromStr;
+
+use anyhow::Context;
+use clap::Parser;
+use data_encoding::HEXLOWER;
+use iroh::{Endpoint, EndpointId, RelayMap, RelayUrl, SecretKey, protocol::Router};
+
+fn relay_map_from_env() -> anyhow::Result<Option<RelayMap>> {
+    match std::env::var("IROH_RELAYS") {
+        Ok(value) if !value.is_empty() => {
+            let parts = value.split(",");
+            let mut urls = Vec::new();
+            for url_string in parts {
+                let url: RelayUrl = url_string
+                    .trim()
+                    .parse()
+                    .with_context(|| "Failed to parse string as relay URL: {url_string}")?;
+                urls.push(url);
+            }
+            Ok(Some(RelayMap::from_iter(urls)))
+        }
+        _ => Ok(None),
+    }
+}
+
+#[derive(Debug, clap::Parser)]
+struct Cli {
+    targets: Vec<EndpointId>,
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
-    // minimal preset that works with a free iroh services project. This will
-    // give a bandwidth bump when using the public relays, and surface your
-    // relay traffic on your project:
-    // let _preset = iroh_services::preset()
-    //     .api_secret_from_str("YOUR_API_SECRET_HERE")?
-    //     .build()?;
+    let cli = Cli::parse();
 
-    // if you are using a secret key from disk, or generally want control over
-    // the ID your endpoint uses, the secret key must be given to the preset
-    // *before* passing it to the endpoint. The access token that the preset creates
-    // to access relays is scoped only to the given key.
-    //
-    // If no key is provided, a random one is generated and passed to the
-    // endpoint.
-    // let secret_key = iroh::SecretKey::generate();
-    // let _preset = iroh_services::preset()
-    //     .secret_key(secret_key)
-    //     .api_secret_from_str("YOUR_API_SECRET_HERE")?
-    //     .build()?;
+    // Create secret key if not set.
+    let secret_key = match std::env::var("IROH_SECRET") {
+        Ok(s) => SecretKey::from_str(&s)
+            .context("Failed to parse IROH_SECRET environment variable as iroh secret key")?,
+        Err(_) => {
+            let s = SecretKey::generate();
+            println!(
+                "Generated a new endpoint secret. To reuse, set\n\tIROH_SECRET={}",
+                HEXLOWER.encode(&s.to_bytes())
+            );
+            s
+        }
+    };
 
-    // pro & enterprise projects have access to custom relays, which are set
-    // with the `relays` method on the builder.
-    // You'll need to replace these strings with the relay urls for your project,
-    // and set the API secret.
+    let relay_map = relay_map_from_env()?.context("Missing IROH_RELAYS environment variable")?;
+
     let preset = iroh_services::preset()
-        .relays([
-            // Replace these with your own relay urls!
-            "https://use1-1.relay.n0.iroh-canary.iroh.link.",
-            "https://usw1-1.relay.n0.iroh-canary.iroh.link.",
-            "https://euc1-1.relay.n0.iroh-canary.iroh.link.",
-            "https://aps1-1.relay.n0.iroh-canary.iroh.link.",
-        ])?
-        .api_secret_from_str("YOUR_API_SECRET_HERE")?
+        .secret_key(secret_key)
+        .relay_map(relay_map)
+        .api_secret_from_env()?
         .build()?;
 
     // once a preset is built, we'll pass it to the endpoint for binding.
     // we clone the preset so we can reuse to get a client builder below
-    let endpoint = Endpoint::bind(preset.clone()).await?;
+    let endpoint = Endpoint::builder(preset.clone()).bind().await?;
 
     // wait for the endpoint to be online, to prove we have an authorized
     // connection to a relay
@@ -63,14 +80,30 @@ async fn main() -> anyhow::Result<()> {
     // endpoint, so you don't need to pass the secret key separately:
     let client = preset.client_builder(&endpoint).build().await?;
 
+    println!("endpoint id: {}", endpoint.id());
+    let router = Router::builder(endpoint)
+        .accept(iroh_ping::ALPN, iroh_ping::Ping::default())
+        .spawn();
+
     // we can also ping the service just to confirm everything is working
-    client.ping().await?;
+    tokio::task::spawn(async move {
+        let res = client.ping().await;
+        println!("Pinged iroh services: {res:?}");
+    });
+
+    for target in cli.targets {
+        println!("ping {target}...");
+        let res = iroh_ping::Ping::new()
+            .ping(router.endpoint(), target.into())
+            .await;
+        println!("ping {target}: {res:?}");
+    }
 
     // keep the connection alive
     println!("waiting for ctrl+c...");
     tokio::signal::ctrl_c().await?;
 
-    endpoint.close().await;
+    router.shutdown().await?;
 
     Ok(())
 }

--- a/examples/relays.rs
+++ b/examples/relays.rs
@@ -1,14 +1,46 @@
-//! This example shows common methods for configuring custom relays provided by iroh services.
-//! All of these leverage the [`iroh_services::preset`] builder to configure the endpoint,
-//! which itself builds an [`iroh::presets::Preset`] to pass to an [`iroh::Endpoint`] on
-//! construction.
+//! Binds an iroh endpoint through the iroh services [`preset`], then keeps it online
+//! by pinging the iroh services relay and any target endpoints passed on the command
+//! line.
 //!
-//! To run these, set IROH_SERVICES_API_SECRET in your environment, using an API secret
-//! from your iroh services project, and then run with `cargo run --example relays`.
+//! The endpoint is configured entirely from the environment, so you can point it at
+//! different relays, reuse an identity, or authorize against your project without
+//! editing the source. The [`preset`] builder produces an [`IrohServicesPreset`]
+//! that is passed to [`Endpoint::builder`] on construction.
 //!
-//! Your app will use only one of these methods, depending on your use case. To test this
-//! example with custom relay URLS, you will need to comment out the secret key preset
-//! example and use the `relays` method instead, pasting in your own relay URLs.
+//! # Environment variables
+//!
+//! - `IROH_SERVICES_API_SECRET`: the API secret from your iroh services project. This
+//!   authorizes the endpoint against the project's relays and is required. Read via
+//!   [`api_secret_from_env`].
+//! - `IROH_SECRET`: the endpoint secret key as a hex string, controlling the endpoint
+//!   id. If unset, a fresh key is generated and its hex encoding is printed so you can
+//!   set it to reuse the same id on the next run.
+//! - `IROH_RELAYS`: a comma-separated list of relay URLs to use instead of the default
+//!   public relay map. Custom relays require a pro or enterprise project. If unset, the
+//!   default public relay map is used.
+//!
+//! # Examples
+//!
+//! Run against the default public relays with a generated identity:
+//!
+//! ```sh
+//! export IROH_SERVICES_API_SECRET=your_api_secret_here
+//! cargo run --example relays
+//! ```
+//!
+//! Reuse an identity and point at your project's custom relays, while pinging a peer:
+//!
+//! ```sh
+//! export IROH_SERVICES_API_SECRET=your_api_secret_here
+//! export IROH_SECRET=your_hex_secret_key_here
+//! export IROH_RELAYS=https://use1-1.relay.example,https://euc1-1.relay.example
+//! cargo run --example relays -- <target-endpoint-id>
+//! ```
+//!
+//! [`preset`]: iroh_services::preset
+//! [`IrohServicesPreset`]: iroh_services::IrohServicesPreset
+//! [`api_secret_from_env`]: iroh_services::PresetBuilder::api_secret_from_env
+//! [`Endpoint::builder`]: iroh::Endpoint::builder
 use std::{
     str::FromStr,
     time::{Duration, Instant},
@@ -17,13 +49,16 @@ use std::{
 use anyhow::{Context, Result};
 use clap::Parser;
 use data_encoding::HEXLOWER;
-use iroh::{Endpoint, EndpointId, RelayMap, RelayUrl, SecretKey, protocol::Router};
+use iroh::{Endpoint, EndpointId, RelayMap, RelayUrl, SecretKey, Watcher, protocol::Router};
 
+/// Bind an iroh services endpoint and ping the given targets over iroh-ping.
 #[derive(Debug, clap::Parser)]
 struct Cli {
+    /// Endpoint IDs to ping. Each is pinged every five seconds.
     targets: Vec<EndpointId>,
 }
 
+/// Binds the endpoint, starts the ping loops, and runs until Ctrl+C.
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
@@ -31,22 +66,26 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let preset = iroh_services::preset()
+        // Read the iroh-services API secret from IROH_SERVICES_API_SECRET.
+        .api_secret_from_env()?
         // Read the endpoint secret key from IROH_SECRET, or create if unset.
         .secret_key(secret_key_from_env()?)
         // Read the relay map from IROH_RELAYS, or use default public relays if unset.
         .relay_map(relay_map_from_env()?)
-        // Read the iroh-services API secret from IROH_SERVICES_API_SECRET.
-        .api_secret_from_env()?
         .build()?;
 
     // Once the preset is built, we'll pass it to the endpoint for binding.
     // We clone the preset so we can reuse to get a client builder below.
     let endpoint = Endpoint::builder(preset.clone()).bind().await?;
+    println!("Endpoint id: {}", endpoint.id());
 
     // Wait for the endpoint to be online, to prove we have an authorized
     // connection to a relay
     endpoint.online().await;
-    println!("endpoint id: {}", endpoint.id());
+    println!(
+        "Endpoint is online. Home relay: {}",
+        endpoint.addr().relay_urls().next().expect("has relay")
+    );
 
     // We create a router to accept ping requests.
     let router = Router::builder(endpoint.clone())
@@ -99,12 +138,12 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+/// Reads the relay map from `IROH_RELAYS`, falling back to the default public relays.
 fn relay_map_from_env() -> Result<RelayMap> {
     match std::env::var("IROH_RELAYS") {
         Ok(value) if !value.is_empty() => {
-            let parts = value.split(",");
             let mut urls = Vec::new();
-            for url_string in parts {
+            for url_string in value.split(",") {
                 let url: RelayUrl = url_string
                     .trim()
                     .parse()
@@ -112,11 +151,11 @@ fn relay_map_from_env() -> Result<RelayMap> {
                 urls.push(url);
             }
             println!(
-                "Using custom relay map:\n    - {}",
+                "Using custom relay map:\n\t- {}",
                 urls.iter()
                     .map(ToString::to_string)
                     .collect::<Vec<_>>()
-                    .join("\n   - ")
+                    .join("\n\t- ")
             );
             Ok(RelayMap::from_iter(urls))
         }
@@ -127,6 +166,7 @@ fn relay_map_from_env() -> Result<RelayMap> {
     }
 }
 
+/// Reads the endpoint secret key from `IROH_SECRET`, generating one if unset.
 fn secret_key_from_env() -> Result<SecretKey> {
     Ok(match std::env::var("IROH_SECRET") {
         Ok(s) => SecretKey::from_str(&s)


### PR DESCRIPTION
## Description

This makes the `relays` example usable as a testing tool without having to edit the source code by reading the relay map from environment variables. Also adds iroh-ping for testing if things work for real.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
