### PR TITLE
fix(client)!: re-send the metrics schema after a reconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1082,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3016,7 +3016,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3108,7 +3108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4201,7 +4201,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,6 +1751,7 @@ dependencies = [
  "temp_env_vars",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0.217", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2.0.12"
 tokio = { version = "1", default-features = false, features = ["sync"] }
+tokio-util = { version = "0.7", default-features = false }
 tracing = "0.1.41"
 uuid = { version = "1.17", features = ["v4", "serde", "v7", "js"] }
 tracing-subscriber = { version = "0.3.20", features = [

--- a/src/client.rs
+++ b/src/client.rs
@@ -866,6 +866,13 @@ impl ClientActor {
     /// The server keeps one metrics decoder per connection, so a fresh
     /// connection also gets a fresh encoder: the next metrics export then
     /// carries the full schema for the server's fresh decoder.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the dial, or the authentication that follows it,
+    /// fails. A connection is stored only once both have succeeded, and a
+    /// connection found closed is cleared before either is attempted, so a
+    /// caller that sees an error has nothing left to clean up.
     async fn connect(&mut self) -> Result<&IrohServicesClient, Error> {
         // A connection the remote has closed (server restart, error close)
         // can't carry requests anymore; drop it and re-dial.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::BTreeMap,
+    fmt::Display,
     str::FromStr,
     sync::{Arc, RwLock},
 };
@@ -860,9 +861,10 @@ impl ClientActor {
                 IrohServicesProtocol,
                 Tx = irpc::channel::oneshot::Sender<Res>,
                 Rx = NoReceiver,
-            >,
+            > + Display,
         Res: RpcMessage,
     {
+        trace!(request = %msg, "client actor send request");
         let client = self.connect().await?;
         let res = client.rpc(msg).await;
         if res.is_err() {
@@ -877,20 +879,17 @@ impl ClientActor {
     }
 
     async fn send_ping(&mut self) -> Result<Pong, Error> {
-        trace!("client actor send ping");
         let req = rand::random();
         self.rpc(Ping { req_id: req }).await
     }
 
     async fn send_name_endpoint(&mut self, name: String) -> Result<(), Error> {
-        trace!("client sending name endpoint request");
         self.rpc(NameEndpoint { name: name.clone() }).await??;
         self.name = Some(name);
         Ok(())
     }
 
     async fn send_set_group(&mut self, group: String) -> Result<(), Error> {
-        trace!("client sending set group request");
         self.rpc(SetGroup {
             group: group.clone(),
         })
@@ -903,7 +902,6 @@ impl ClientActor {
         &mut self,
         attributes: BTreeMap<String, String>,
     ) -> Result<(), Error> {
-        trace!("client sending set attributes request");
         self.rpc(SetAttributes {
             attributes: attributes.clone(),
         })
@@ -913,7 +911,6 @@ impl ClientActor {
     }
 
     async fn send_metrics(&mut self) -> Result<(), Error> {
-        trace!("client actor send metrics");
         // Connecting replaces the encoder, so it must happen before the
         // export: the first update on a fresh connection has to carry the
         // schema for the server's fresh decoder.
@@ -929,7 +926,6 @@ impl ClientActor {
     }
 
     async fn grant_cap(&mut self, cap: Rcan<Caps>) -> Result<(), Error> {
-        trace!("client actor grant capability");
         self.rpc(crate::protocol::GrantCap { cap }).await??;
         Ok(())
     }
@@ -938,7 +934,6 @@ impl ClientActor {
         &mut self,
         report: crate::net_diagnostics::DiagnosticsReport,
     ) -> Result<(), Error> {
-        trace!("client actor publish network diagnostics");
         let req = PutNetworkDiagnostics { report };
         self.rpc(req).await??;
         Ok(())

--- a/src/client.rs
+++ b/src/client.rs
@@ -331,12 +331,22 @@ impl From<irpc::Error> for BuildError {
     }
 }
 
+/// How long [`Client::shutdown`] lets a request already in flight finish.
+///
+/// Dropping a request mid-flight resets its stream, and the server treats that
+/// as the connection failing: it stops reading requests and tears the
+/// connection down. Letting the request finish keeps the connection usable for
+/// the final metrics push. Requests to a responsive server complete in
+/// fast, so this only runs out when the server has stopped answering,
+/// in which case the final metrics push is then skipped.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(3);
+
 /// How long [`Client::shutdown`] waits for the final metrics push.
 ///
 /// The push goes over an established connection, so it is normally well under
 /// this. The bound covers a peer that has gone silent without closing, where
 /// the request would otherwise hang until the connection times out.
-const SHUTDOWN_FLUSH_TIMEOUT: Duration = Duration::from_secs(3);
+const SHUTDOWN_FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Minimum length in bytes for an endpoint name.
 pub const CLIENT_NAME_MIN_LENGTH: usize = 2;
@@ -526,18 +536,15 @@ impl Client {
             .map_err(|e| Error::Other(anyhow!("response on internal channel: {:?}", e)))?
     }
 
-    /// Shuts down the client, pushing one final round of metrics first.
+    /// Shuts down the client, after pushing one final round of metrics.
     ///
-    /// Returns once the background actor has stopped, so requests on any clone
-    /// of this client will fail afterwards. Dropping the client without calling
-    /// this aborts the actor immediately, losing any metrics accumulated since
-    /// the last interval push.
+    /// Calling this aborts any inflight requests, and all subsequent requests
+    /// triggered via methods on [`Self`] will fail. If the client is currently
+    /// connected, it will send one final metrics update before shutting down
+    /// the client actor.
     ///
-    /// Any request in flight is cancelled rather than awaited, so a client that
-    /// cannot reach the server shuts down promptly instead of inheriting that
-    /// request's timeout. The final push is best effort: it happens only when
-    /// the metrics interval is enabled and a connection is already established,
-    /// gets a few seconds to complete, and errors are logged and ignored.
+    /// Dropping the client without calling this method immediately stops the
+    /// actor without a final metrics push.
     pub async fn shutdown(&self) {
         self.shutdown.cancel();
         // The actor drops the inbox receiver on its way out.
@@ -717,9 +724,9 @@ impl ClientActor {
     /// Runs the actor until the inbox closes or `shutdown` is cancelled, then
     /// pushes one final round of metrics.
     ///
-    /// Cancellation drops whatever [`Self::run_inner`] is awaiting, so a
-    /// request in flight, most importantly a dial to a server that never
-    /// answers, does not hold up the shutdown.
+    /// Cancelling `shutdown` drops whatever [`Self::run_inner`] is awaiting,
+    /// including all in-flight or queued requests. We do this so that a
+    /// pending dial does not hold up shutdown.
     async fn run(
         mut self,
         interval: Option<Duration>,
@@ -727,16 +734,23 @@ impl ClientActor {
         shutdown: CancellationToken,
     ) {
         let metrics_enabled = interval.is_some();
-        tokio::select! {
-            biased;
-            () = shutdown.cancelled() => trace!("client actor cancelled"),
-            () = self.run_inner(interval, &mut inbox) => {},
-        }
+        let shutdown_and_grace_period_expired = async {
+            shutdown.cancelled().await;
+            n0_future::time::sleep(SHUTDOWN_GRACE).await;
+        };
+
+        let clean_shutdown = tokio::select! {
+            () = self.run_inner(interval, &mut inbox, &shutdown) => true,
+            () = shutdown_and_grace_period_expired => {
+                debug!("shutdown grace elapsed, dropping the request in flight");
+                false
+            }
+        };
 
         // Flush only over a connection that already exists. Dialing here would
         // reintroduce the stall that cancelling just avoided, and an endpoint
         // that never connected has nothing the server could attribute.
-        if metrics_enabled && self.is_connected() {
+        if clean_shutdown && metrics_enabled && self.is_connected() {
             match n0_future::time::timeout(SHUTDOWN_FLUSH_TIMEOUT, self.send_metrics()).await {
                 Ok(Ok(())) => trace!("pushed final metrics on shutdown"),
                 Ok(Err(err)) => debug!(%err, "failed to push final metrics on shutdown"),
@@ -750,6 +764,7 @@ impl ClientActor {
         &mut self,
         interval: Option<Duration>,
         inbox: &mut tokio::sync::mpsc::Receiver<ClientActorMessage>,
+        shutdown: &CancellationToken,
     ) {
         let mut metrics_timer = interval.map(|interval| n0_future::time::interval(interval));
         trace!("starting client actor");
@@ -778,6 +793,12 @@ impl ClientActor {
             trace!("client actor tick");
             tokio::select! {
                 biased;
+                // Only reached between requests: while an arm below is awaiting,
+                // this select is not polled, so the request finishes first.
+                () = shutdown.cancelled() => {
+                    trace!("client actor observed shutdown between requests");
+                    break;
+                }
                 Some(msg) = inbox.recv() => {
                     match msg {
                         ClientActorMessage::Ping { done } => {
@@ -934,14 +955,15 @@ impl ClientActor {
         trace!(request = %msg, "client actor send request");
         let client = self.connect().await?;
         let res = client.rpc(msg).await;
+
         if let Err(err) = &res
             && is_connection_lost(err)
         {
-            // The connection is gone or in an unknown state; the next request
-            // dials and authenticates afresh. Server-side errors arrive as
-            // `Ok(Err(RemoteError))` and keep the connection.
+            // The connection is gone or in an unknown state. Clear the client
+            // so that the next request dials and authenticates.
             self.client = None;
         }
+
         res.inspect_err(|err| warn!("rpc error: {err}"))
             .map_err(Error::from)
     }
@@ -1112,7 +1134,7 @@ mod tests {
             CLIENT_ATTRIBUTES_MAX_COUNT, CLIENT_NAME_MAX_LENGTH, Error, ValidateAttributesError,
             ValidateNameError, is_connection_lost,
         },
-        protocol::{ALPN, IrohServicesProtocol, ServicesMessage},
+        protocol::{ALPN, IrohServicesProtocol, Pong, ServicesMessage},
     };
 
     /// What the test server recorded about one PutMetrics request.
@@ -1392,6 +1414,130 @@ mod tests {
             meta: Default::default(),
         };
         assert!(is_connection_lost(&closed));
+    }
+
+    /// Mirrors the backend's request loop: reads are sequential and any error
+    /// ends the loop and the connection with it.
+    #[derive(Debug)]
+    struct SlowServer {
+        /// Set once the server has answered a Ping without the stream failing.
+        ping_answered: Arc<AtomicBool>,
+        /// Counts metrics pushes the server actually read.
+        metrics_seen: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl ProtocolHandler for SlowServer {
+        async fn accept(&self, connection: Connection) -> Result<(), AcceptError> {
+            self.handle(connection).await.map_err(|e| {
+                let boxed: Box<dyn std::error::Error + Send + Sync> = e.into();
+                AcceptError::from(AnyError::from(boxed))
+            })
+        }
+    }
+
+    impl SlowServer {
+        async fn handle(&self, connection: Connection) -> anyhow::Result<()> {
+            let Some(first) = read_request::<IrohServicesProtocol>(&connection).await? else {
+                return Ok(());
+            };
+            let ServicesMessage::Auth(WithChannels { tx, .. }) = first else {
+                anyhow::bail!("expected auth first");
+            };
+            tx.send(()).await?;
+
+            loop {
+                let Ok(Some(request)) = read_request::<IrohServicesProtocol>(&connection).await
+                else {
+                    return Ok(());
+                };
+                match request {
+                    ServicesMessage::Ping(WithChannels { inner, tx, .. }) => {
+                        // long enough for shutdown to land while this is in flight
+                        n0_future::time::sleep(Duration::from_millis(300)).await;
+                        // a client that dropped the request resets the stream,
+                        // and this send is where the server finds out
+                        tx.send(Pong {
+                            req_id: inner.req_id,
+                        })
+                        .await?;
+                        self.ping_answered.store(true, Ordering::SeqCst);
+                    }
+                    ServicesMessage::PutMetrics(WithChannels { tx, .. }) => {
+                        self.metrics_seen.fetch_add(1, Ordering::SeqCst);
+                        tx.send(Ok(())).await?;
+                    }
+                    _ => anyhow::bail!("unexpected request"),
+                }
+            }
+        }
+    }
+
+    /// Assert that shutting down with a request in flight lets that request
+    /// finish, so the final metrics push still reaches the server.
+    ///
+    /// Dropping the request instead would reset its stream, and the server
+    /// treats that as the connection failing: it stops reading, so the push
+    /// that shutdown exists for is never seen.
+    #[tokio::test]
+    async fn test_shutdown_drains_request_in_flight() {
+        let mut rng = rand::rngs::ChaCha8Rng::seed_from_u64(9);
+        let server_ep = Endpoint::builder(presets::Minimal).bind().await.unwrap();
+        let client_ep = Endpoint::builder(presets::Minimal).bind().await.unwrap();
+
+        let ping_answered = Arc::new(AtomicBool::new(false));
+        let metrics_seen = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let router = Router::builder(server_ep.clone())
+            .accept(
+                ALPN,
+                SlowServer {
+                    ping_answered: ping_answered.clone(),
+                    metrics_seen: metrics_seen.clone(),
+                },
+            )
+            .spawn();
+
+        let shared_secret = SecretKey::from_bytes(&rng.random());
+        let cap = create_api_token_from_secret_key(
+            shared_secret,
+            client_ep.id(),
+            Duration::from_secs(3600),
+            Caps::for_shared_secret(),
+        )
+        .unwrap();
+
+        let client = Client::builder(&client_ep)
+            .rcan(cap)
+            .unwrap()
+            .remote(server_ep.addr())
+            // long enough that only the startup tick fires on its own
+            .metrics_interval(Duration::from_secs(3600))
+            .build()
+            .await
+            .unwrap();
+
+        // let the startup metrics push establish the connection
+        n0_future::time::sleep(Duration::from_millis(500)).await;
+        let after_startup = metrics_seen.load(Ordering::SeqCst);
+        assert_eq!(after_startup, 1, "expected the startup metrics push");
+
+        // put a ping in flight, then shut down while the server sits on it
+        let pinging = client.clone();
+        let ping = n0_future::task::spawn(async move { pinging.ping().await });
+        n0_future::time::sleep(Duration::from_millis(100)).await;
+        client.shutdown().await;
+
+        assert!(
+            ping_answered.load(Ordering::SeqCst),
+            "the ping in flight was dropped, so the server saw its stream fail"
+        );
+        assert_eq!(
+            metrics_seen.load(Ordering::SeqCst),
+            after_startup + 1,
+            "the final metrics push did not reach the server"
+        );
+
+        let _ = ping.await;
+        router.shutdown().await.unwrap();
     }
 
     /// Assert that shutdown does not wait for a request in flight.

--- a/src/client.rs
+++ b/src/client.rs
@@ -685,52 +685,50 @@ impl ClientActor {
                             let res = self.send_ping().await;
                             if let Err(err) = done.send(res) {
                                 debug!("failed to send ping: {:#?}", err);
-                                self.authorized = false;
                             }
                         },
-                        ClientActorMessage::SendMetrics{ done } => {
+                        ClientActorMessage::SendMetrics { done } => {
                             trace!("sending metrics manually triggered");
                             let res = self.send_metrics().await;
                             if let Err(err) = done.send(res) {
                                 debug!("failed to push metrics: {:#?}", err);
-                                self.authorized = false;
                             }
                         }
-                        ClientActorMessage::GrantCap{ cap, done } => {
+                        ClientActorMessage::GrantCap { cap, done } => {
                             let res = self.grant_cap(*cap).await;
                             if let Err(err) = done.send(res) {
                                 warn!("failed to grant capability: {:#?}", err);
                             }
                         }
-                        ClientActorMessage::ReadName{ done } => {
+                        ClientActorMessage::ReadName { done } => {
                             if let Err(err) = done.send(self.name.clone()) {
                                 warn!("sending name value: {:#?}", err);
                             }
                         }
-                        ClientActorMessage::ReadGroup{ done } => {
+                        ClientActorMessage::ReadGroup { done } => {
                             if let Err(err) = done.send(self.group.clone()) {
                                 warn!("sending group value: {:#?}", err);
                             }
                         }
-                        ClientActorMessage::NameEndpoint{ name, done } => {
+                        ClientActorMessage::NameEndpoint { name, done } => {
                             let res = self.send_name_endpoint(name).await;
                             if let Err(err) = done.send(res) {
                                 warn!("failed to name endpoint: {:#?}", err);
                             }
                         }
-                        ClientActorMessage::SetGroup{ group, done } => {
+                        ClientActorMessage::SetGroup { group, done } => {
                             let res = self.send_set_group(group).await;
                             if let Err(err) = done.send(res) {
                                 warn!("failed to set group: {:#?}", err);
                             }
                         }
-                        ClientActorMessage::SetAttributes{ attributes, done } => {
+                        ClientActorMessage::SetAttributes { attributes, done } => {
                             let res = self.send_set_attributes(attributes).await;
                             if let Err(err) = done.send(res) {
                                 warn!("failed to set attributes: {:#?}", err);
                             }
                         }
-                        ClientActorMessage::SetAttribute{ key, value, done } => {
+                        ClientActorMessage::SetAttribute { key, value, done } => {
                             // Merge into the current set and validate the union:
                             // adding one valid entry to a valid set can still
                             // exceed the max entry count, so the single entry
@@ -747,7 +745,7 @@ impl ClientActor {
                                 warn!("failed to set attribute: {:#?}", err);
                             }
                         }
-                        ClientActorMessage::PutNetworkDiagnostics{ report, done } => {
+                        ClientActorMessage::PutNetworkDiagnostics { report, done } => {
                             let res = self.put_network_diagnostics(*report).await;
                             if let Err(err) = done.send(res) {
                                 warn!("failed to publish network diagnostics: {:#?}", err);
@@ -774,7 +772,6 @@ impl ClientActor {
                     trace!("metrics send tick");
                     if let Err(err) = self.send_metrics().await {
                         debug!("failed to push metrics: {:#?}", err);
-                        self.authorized = false;
                     }
                 },
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,10 +5,13 @@ use std::{
 };
 
 use anyhow::{Result, anyhow, ensure};
-use iroh::{Endpoint, EndpointAddr, EndpointId, endpoint::ConnectError};
+use iroh::{
+    Endpoint, EndpointAddr, EndpointId,
+    endpoint::{ConnectError, Connection},
+};
 use iroh_metrics::{MetricsGroup, Registry, encoding::Encoder};
 use irpc::{Channels, RpcMessage, WithChannels, channel::none::NoReceiver};
-use irpc_iroh::IrohLazyRemoteConnection;
+use irpc_iroh::IrohRemoteConnection;
 use n0_error::StackResultExt;
 use n0_future::{task::AbortOnDropHandle, time::Duration};
 use rcan::Rcan;
@@ -257,20 +260,18 @@ impl ClientBuilder {
         let remote = self.remote.ok_or(BuildError::MissingRemote)?;
         let capabilities = self.cap.ok_or(BuildError::MissingCapability)?;
 
-        let conn = IrohLazyRemoteConnection::new(self.endpoint.clone(), remote, ALPN.to_vec());
-        let irpc_client = IrohServicesClient::boxed(conn);
-
         let registry = Arc::new(RwLock::new(self.registry));
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         let actor_task = AbortOnDropHandle::new(n0_future::task::spawn(
             ClientActor {
                 capabilities,
-                client: irpc_client,
+                endpoint: self.endpoint.clone(),
+                remote,
+                client: None,
                 name: self.name.clone(),
                 group: self.group.clone(),
                 attributes: self.attributes.clone().unwrap_or_default(),
                 session_id: Uuid::new_v4(),
-                authorized: false,
                 encoder: Encoder::new(registry.clone()),
                 registry,
             }
@@ -286,6 +287,7 @@ impl ClientBuilder {
 }
 
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum BuildError {
     #[error("Missing remote endpoint to dial")]
     MissingRemote,
@@ -379,6 +381,7 @@ fn validate_attributes(attrs: &BTreeMap<String, String>) -> Result<(), ValidateA
 }
 
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Invalid endpoint name: {0}")]
     InvalidName(#[from] ValidateNameError),
@@ -389,6 +392,8 @@ pub enum Error {
     #[error("Remote error: {0}")]
     Remote(#[from] RemoteError),
     #[error("Connection error: {0}")]
+    Connect(#[from] ConnectError),
+    #[error("Rpc error: {0}")]
     Rpc(#[from] irpc::Error),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -492,7 +497,6 @@ impl Client {
 
         rx.await
             .map_err(|e| Error::Other(anyhow!("response on internal channel: {:?}", e)))?
-            .map_err(Error::Remote)
     }
 
     /// immediately send a single dump of metrics to iroh-services. It's not necessary
@@ -507,7 +511,6 @@ impl Client {
 
         rx.await
             .map_err(|e| Error::Other(anyhow!("response on internal channel: {:?}", e)))?
-            .map_err(Error::Remote)
     }
 
     /// Shuts down the client, pushing one final round of metrics first.
@@ -586,10 +589,10 @@ impl Client {
 
 enum ClientActorMessage {
     SendMetrics {
-        done: oneshot::Sender<Result<(), RemoteError>>,
+        done: oneshot::Sender<Result<(), Error>>,
     },
     Ping {
-        done: oneshot::Sender<Result<Pong, RemoteError>>,
+        done: oneshot::Sender<Result<Pong, Error>>,
     },
     // GrantCap is used by the `client_host` feature flag
     #[allow(dead_code)]
@@ -610,15 +613,15 @@ enum ClientActorMessage {
     },
     NameEndpoint {
         name: String,
-        done: oneshot::Sender<Result<(), RemoteError>>,
+        done: oneshot::Sender<Result<(), Error>>,
     },
     SetGroup {
         group: String,
-        done: oneshot::Sender<Result<(), RemoteError>>,
+        done: oneshot::Sender<Result<(), Error>>,
     },
     SetAttributes {
         attributes: BTreeMap<String, String>,
-        done: oneshot::Sender<Result<(), RemoteError>>,
+        done: oneshot::Sender<Result<(), Error>>,
     },
     SetAttribute {
         key: String,
@@ -633,16 +636,58 @@ enum ClientActorMessage {
     },
 }
 
+/// An irpc client bound to a single authenticated connection.
+///
+/// The server accepts requests only after an `Auth` as the very first
+/// request on a connection, so [`RpcClient::connect`] dials and
+/// authenticates in one step; a value of this type never exists
+/// unauthenticated.
+struct RpcClient {
+    /// Kept alongside the irpc client to detect a remote close.
+    connection: Connection,
+    irpc: IrohServicesClient,
+}
+
+impl RpcClient {
+    /// Dials the remote and authenticates as the connection's first request.
+    async fn connect(
+        endpoint: &Endpoint,
+        remote: EndpointAddr,
+        caps: Rcan<Caps>,
+    ) -> Result<Self, Error> {
+        trace!("client connecting and authorizing");
+        let connection = endpoint
+            .connect(remote, ALPN)
+            .await
+            .inspect_err(|err| debug!("connect failed: {err:?}"))?;
+        let irpc = IrohServicesClient::boxed(IrohRemoteConnection::new(connection.clone()));
+        irpc.rpc(Auth { caps })
+            .await
+            .inspect_err(|err| debug!("authorization failed: {err:?}"))
+            .map_err(|err| RemoteError::AuthError(err.to_string()))?;
+        Ok(Self { connection, irpc })
+    }
+}
+
 struct ClientActor {
     capabilities: Rcan<Caps>,
-    client: IrohServicesClient,
+    endpoint: Endpoint,
+    remote: EndpointAddr,
+    /// The active authenticated connection, established on demand.
+    ///
+    /// The actor owns the connection lifecycle rather than using a lazy
+    /// reconnecting client: the server requires `Auth` as the first request
+    /// on every connection, so a transparent mid-request reconnect would send
+    /// an unauthenticated request that the server rejects. [`Self::connect`]
+    /// establishes this; [`Self::rpc`] clears it on transport errors so the
+    /// next request re-dials and re-authenticates.
+    client: Option<RpcClient>,
     name: Option<String>,
     group: Option<String>,
     attributes: BTreeMap<String, String>,
     session_id: Uuid,
-    authorized: bool,
     encoder: Encoder,
-    /// Kept so auth() can rebuild the encoder to re-send the metrics schema.
+    /// Kept so connect() can rebuild the encoder to re-send the metrics schema.
     registry: Arc<RwLock<Registry>>,
 }
 
@@ -681,7 +726,7 @@ impl ClientActor {
                 biased;
                 Some(msg) = inbox.recv() => {
                     match msg {
-                        ClientActorMessage::Ping{ done } => {
+                        ClientActorMessage::Ping { done } => {
                             let res = self.send_ping().await;
                             if let Err(err) = done.send(res) {
                                 debug!("failed to send ping: {:#?}", err);
@@ -737,7 +782,7 @@ impl ClientActor {
                             merged.insert(key, value);
                             let res = match validate_attributes(&merged) {
                                 Ok(()) => {
-                                    self.send_set_attributes(merged).await.map_err(Error::Remote)
+                                    self.send_set_attributes(merged).await
                                 }
                                 Err(err) => Err(Error::from(err)),
                             };
@@ -779,30 +824,35 @@ impl ClientActor {
         debug!("client actor shut down");
     }
 
-    // sends an authorization request to the server
-    async fn auth(&mut self) -> Result<(), RemoteError> {
-        if self.authorized {
-            return Ok(());
+    /// Returns the client for the active connection, establishing one if needed.
+    ///
+    /// The server keeps one metrics decoder per connection, so a fresh
+    /// connection also gets a fresh encoder: the next metrics export then
+    /// carries the full schema for the server's fresh decoder.
+    async fn connect(&mut self) -> Result<&IrohServicesClient, Error> {
+        // A connection the remote has closed (server restart, error close)
+        // can't carry requests anymore; drop it and re-dial.
+        if let Some(client) = &self.client
+            && let Some(reason) = client.connection.close_reason()
+        {
+            debug!(%reason, "connection closed by remote, reconnecting");
+            self.client = None;
         }
-        trace!("client authorizing");
-        self.client
-            .rpc(Auth {
-                caps: self.capabilities.clone(),
-            })
-            .await
-            .inspect_err(|e| debug!("authorization failed: {:?}", e))
-            .map_err(|e| RemoteError::AuthError(e.to_string()))?;
-        self.authorized = true;
-        // A completed handshake means a fresh connection, and the server keeps
-        // one metrics decoder per connection. A new encoder starts at schema
-        // version zero, so the next export carries the full schema for that
-        // decoder. Re-importing a schema is idempotent server-side, so
-        // re-sending after a spurious re-auth is harmless.
-        self.encoder = Encoder::new(self.registry.clone());
-        Ok(())
+        if self.client.is_none() {
+            let client = RpcClient::connect(
+                &self.endpoint,
+                self.remote.clone(),
+                self.capabilities.clone(),
+            )
+            .await?;
+            // Recreate the metrics encoder to force sending the schema on the next metrics push.
+            self.encoder = Encoder::new(self.registry.clone());
+            self.client = Some(client);
+        }
+        Ok(&self.client.as_ref().expect("just checked").irpc)
     }
 
-    async fn rpc<Req, Res>(&mut self, msg: Req) -> Result<Res, RemoteError>
+    async fn rpc<Req, Res>(&mut self, msg: Req) -> Result<Res, Error>
     where
         IrohServicesProtocol: From<Req>,
         ServicesMessage: From<WithChannels<Req, IrohServicesProtocol>>,
@@ -813,29 +863,33 @@ impl ClientActor {
             >,
         Res: RpcMessage,
     {
-        self.auth().await?;
-        let res = self.client.rpc(msg).await;
+        let client = self.connect().await?;
+        let res = client.rpc(msg).await;
         if res.is_err() {
-            self.authorized = false;
+            // A transport-level failure means the connection is gone or in an
+            // unknown state; the next request dials and authenticates afresh.
+            // Server-side errors arrive as `Ok(Err(RemoteError))` and keep the
+            // connection.
+            self.client = None;
         }
-        res.inspect_err(|e| warn!("rpc error: {e}"))
-            .map_err(|_| RemoteError::InternalServerError)
+        res.inspect_err(|err| warn!("rpc error: {err}"))
+            .map_err(Error::from)
     }
 
-    async fn send_ping(&mut self) -> Result<Pong, RemoteError> {
+    async fn send_ping(&mut self) -> Result<Pong, Error> {
         trace!("client actor send ping");
         let req = rand::random();
         self.rpc(Ping { req_id: req }).await
     }
 
-    async fn send_name_endpoint(&mut self, name: String) -> Result<(), RemoteError> {
+    async fn send_name_endpoint(&mut self, name: String) -> Result<(), Error> {
         trace!("client sending name endpoint request");
         self.rpc(NameEndpoint { name: name.clone() }).await??;
         self.name = Some(name);
         Ok(())
     }
 
-    async fn send_set_group(&mut self, group: String) -> Result<(), RemoteError> {
+    async fn send_set_group(&mut self, group: String) -> Result<(), Error> {
         trace!("client sending set group request");
         self.rpc(SetGroup {
             group: group.clone(),
@@ -848,7 +902,7 @@ impl ClientActor {
     async fn send_set_attributes(
         &mut self,
         attributes: BTreeMap<String, String>,
-    ) -> Result<(), RemoteError> {
+    ) -> Result<(), Error> {
         trace!("client sending set attributes request");
         self.rpc(SetAttributes {
             attributes: attributes.clone(),
@@ -858,8 +912,12 @@ impl ClientActor {
         Ok(())
     }
 
-    async fn send_metrics(&mut self) -> Result<(), RemoteError> {
+    async fn send_metrics(&mut self) -> Result<(), Error> {
         trace!("client actor send metrics");
+        // Connecting replaces the encoder, so it must happen before the
+        // export: the first update on a fresh connection has to carry the
+        // schema for the server's fresh decoder.
+        self.connect().await?;
         let update = self.encoder.export();
         // let delta = update_delta(&self.latest_ackd_update, &update);
         let req = PutMetrics {
@@ -900,7 +958,6 @@ async fn set_name_inner(
         .map_err(|_| Error::Other(anyhow!("sending name endpoint request")))?;
     rx.await
         .map_err(|e| Error::Other(anyhow!("response on internal channel: {:?}", e)))?
-        .map_err(Error::Remote)
 }
 
 async fn set_group_inner(
@@ -916,7 +973,6 @@ async fn set_group_inner(
         .map_err(|_| Error::Other(anyhow!("sending set group request")))?;
     rx.await
         .map_err(|e| Error::Other(anyhow!("response on internal channel: {:?}", e)))?
-        .map_err(Error::Remote)
 }
 
 async fn set_attributes_inner(
@@ -935,7 +991,6 @@ async fn set_attributes_inner(
         .map_err(|_| Error::Other(anyhow!("sending set attributes request")))?;
     rx.await
         .map_err(|e| Error::Other(anyhow!("response on internal channel: {:?}", e)))?
-        .map_err(Error::Remote)
 }
 
 async fn set_attribute_inner(
@@ -1007,7 +1062,8 @@ mod tests {
     /// In-process stand-in for the services backend.
     ///
     /// Mirrors the real server's session rules: the first request on every
-    /// connection must be Auth, and the metrics decoder lives per connection.
+    /// connection must be Auth, a repeat Auth on a live connection closes it,
+    /// and the metrics decoder lives per connection.
     #[derive(Debug)]
     struct RecordingServer {
         seen: tokio::sync::mpsc::UnboundedSender<SeenUpdate>,
@@ -1025,8 +1081,17 @@ mod tests {
 
     impl RecordingServer {
         async fn handle_connection(&self, connection: Connection) -> anyhow::Result<()> {
+            let Some(first_request) = read_request::<IrohServicesProtocol>(&connection).await?
+            else {
+                return Ok(());
+            };
+            let ServicesMessage::Auth(WithChannels { tx, .. }) = first_request else {
+                connection.close(400u32.into(), b"Expected initial auth message");
+                return Ok(());
+            };
+            tx.send(()).await?;
+
             let mut decoder = Decoder::default();
-            let mut authed = false;
             loop {
                 let Some(request) = read_request::<IrohServicesProtocol>(&connection).await? else {
                     return Ok(());
@@ -1038,11 +1103,11 @@ mod tests {
                     return Ok(());
                 }
                 match request {
-                    ServicesMessage::Auth(WithChannels { tx, .. }) => {
-                        authed = true;
-                        tx.send(()).await?;
+                    ServicesMessage::Auth(_) => {
+                        connection.close(400u32.into(), b"Unexpected auth message");
+                        anyhow::bail!("client re-sent auth on a live connection");
                     }
-                    ServicesMessage::PutMetrics(WithChannels { inner, tx, .. }) if authed => {
+                    ServicesMessage::PutMetrics(WithChannels { inner, tx, .. }) => {
                         let has_schema = inner.update.schema.is_some();
                         decoder.import(inner.update);
                         let decoded_items = decoder.iter().count();
@@ -1053,8 +1118,8 @@ mod tests {
                         tx.send(Ok(())).await?;
                     }
                     _ => {
-                        connection.close(400u32.into(), b"Expected initial auth message");
-                        return Ok(());
+                        connection.close(400u32.into(), b"Unexpected message in test");
+                        anyhow::bail!("unexpected message in test");
                     }
                 }
             }
@@ -1106,12 +1171,21 @@ mod tests {
         assert!(first.has_schema);
         assert!(first.decoded_items > 0);
 
-        // Steady state suppresses the schema; the connection's decoder
-        // already has it and keeps decoding.
-        client.push_metrics().await.unwrap();
-        let second = seen_rx.recv().await.unwrap();
-        assert!(!second.has_schema);
-        assert!(second.decoded_items > 0);
+        // Steady state stops sending the schema. The endpoint's own metric
+        // families may still grow for a few exports right after connecting
+        // (each growth re-publishes the schema), so push until the schema
+        // settles; the connection's decoder keeps decoding throughout.
+        let mut settled = false;
+        for _ in 0..20 {
+            client.push_metrics().await.unwrap();
+            let seen = seen_rx.recv().await.unwrap();
+            assert!(seen.decoded_items > 0);
+            if !seen.has_schema {
+                settled = true;
+                break;
+            }
+        }
+        assert!(settled, "schema must stop being sent once it is unchanged");
 
         // The server drops the connection mid-request: one failed round trip.
         drop_next.store(true, Ordering::SeqCst);
@@ -1475,14 +1549,14 @@ mod tests {
             ))
         ));
 
-        // A valid single attribute passes validation, then reaches the remote
-        // layer (no server) and surfaces a remote error, proving set_attribute
+        // A valid single attribute passes validation, then reaches the dial
+        // (no server) and surfaces a connect error, proving set_attribute
         // is wired through the actor/RPC path.
         let err = client
             .set_attribute("firmware", "2.1.0")
             .await
             .expect_err("no server: remote call must fail after validation passes");
-        assert!(matches!(err, Error::Remote(_)), "got {err:?}");
+        assert!(matches!(err, Error::Connect(_)), "got {err:?}");
     }
 
     #[tokio::test]
@@ -1525,8 +1599,8 @@ mod tests {
 
     /// Boundary "accepted" case for the runtime setter. Without a live server we
     /// cannot assert success; instead we assert the input passes local validation
-    /// and the call proceeds to the (failing) remote layer, surfacing
-    /// `Error::Remote` rather than an `Error::InvalidAttributes` validation error.
+    /// and the call proceeds to the (failing) dial, surfacing `Error::Connect`
+    /// rather than an `Error::InvalidAttributes` validation error.
     #[tokio::test]
     async fn test_set_attributes_runtime_boundary_accepted() {
         let client = build_serverless_client(4).await;
@@ -1538,8 +1612,8 @@ mod tests {
             .await
             .expect_err("no server: remote call must fail after validation passes");
         assert!(
-            matches!(err, Error::Remote(_)),
-            "expected a remote error (validation accepted), got {err:?}"
+            matches!(err, Error::Connect(_)),
+            "expected a connect error (validation accepted), got {err:?}"
         );
 
         // exactly CLIENT_ATTRIBUTES_MAX_COUNT entries is accepted by validation
@@ -1551,8 +1625,8 @@ mod tests {
             .await
             .expect_err("no server: remote call must fail after validation passes");
         assert!(
-            matches!(err, Error::Remote(_)),
-            "expected a remote error (validation accepted), got {err:?}"
+            matches!(err, Error::Connect(_)),
+            "expected a connect error (validation accepted), got {err:?}"
         );
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1126,7 +1126,7 @@ mod tests {
     use temp_env_vars::temp_env_vars;
 
     use crate::{
-        Client,
+        Client, ClientBuilder,
         api_secret::ApiSecret,
         caps::{Cap, Caps, create_api_token_from_secret_key},
         client::{
@@ -1144,27 +1144,44 @@ mod tests {
         decoded_items: usize,
     }
 
+    /// What the test server recorded, in arrival order.
+    #[derive(Debug)]
+    enum Seen {
+        Metrics(SeenUpdate),
+        /// A Ping whose response reached the client without the stream failing.
+        PingAnswered,
+    }
+
     /// In-process stand-in for the services backend.
     ///
     /// Mirrors the real server's session rules: the first request on every
     /// connection must be Auth, a repeat Auth on a live connection closes it,
-    /// and the metrics decoder lives per connection.
+    /// and the metrics decoder lives per connection. Requests are read one at
+    /// a time and any error ends the connection, as in the backend, so a
+    /// client that drops a request mid-flight takes the connection with it.
     #[derive(Debug)]
-    struct RecordingServer {
-        seen: tokio::sync::mpsc::UnboundedSender<SeenUpdate>,
+    struct TestServer {
+        seen: tokio::sync::mpsc::UnboundedSender<Seen>,
+        /// Kills the next connection without answering, simulating a restart.
         drop_next: Arc<AtomicBool>,
+        /// Held before answering a Ping, so a test can catch one in flight.
+        ping_delay: Duration,
     }
 
-    impl ProtocolHandler for RecordingServer {
-        async fn accept(&self, connection: Connection) -> Result<(), AcceptError> {
-            self.handle_connection(connection).await.map_err(|e| {
-                let boxed: Box<dyn std::error::Error + Send + Sync> = e.into();
-                AcceptError::from(AnyError::from(boxed))
-            })
+    impl TestServer {
+        fn new(seen: tokio::sync::mpsc::UnboundedSender<Seen>) -> Self {
+            Self {
+                seen,
+                drop_next: Arc::new(AtomicBool::new(false)),
+                ping_delay: Duration::ZERO,
+            }
         }
-    }
 
-    impl RecordingServer {
+        fn ping_delay(mut self, delay: Duration) -> Self {
+            self.ping_delay = delay;
+            self
+        }
+
         async fn handle_connection(&self, connection: Connection) -> anyhow::Result<()> {
             let Some(first_request) = read_request::<IrohServicesProtocol>(&connection).await?
             else {
@@ -1178,7 +1195,8 @@ mod tests {
 
             let mut decoder = Decoder::default();
             loop {
-                let Some(request) = read_request::<IrohServicesProtocol>(&connection).await? else {
+                let Ok(Some(request)) = read_request::<IrohServicesProtocol>(&connection).await
+                else {
                     return Ok(());
                 };
                 if self.drop_next.swap(false, Ordering::SeqCst) {
@@ -1192,14 +1210,23 @@ mod tests {
                         connection.close(400u32.into(), b"Unexpected auth message");
                         anyhow::bail!("client re-sent auth on a live connection");
                     }
+                    ServicesMessage::Ping(WithChannels { inner, tx, .. }) => {
+                        n0_future::time::sleep(self.ping_delay).await;
+                        // A client that dropped this request has reset the
+                        // stream, and this send is where the server finds out.
+                        tx.send(Pong {
+                            req_id: inner.req_id,
+                        })
+                        .await?;
+                        let _ = self.seen.send(Seen::PingAnswered);
+                    }
                     ServicesMessage::PutMetrics(WithChannels { inner, tx, .. }) => {
                         let has_schema = inner.update.schema.is_some();
                         decoder.import(inner.update);
-                        let decoded_items = decoder.iter().count();
-                        let _ = self.seen.send(SeenUpdate {
+                        let _ = self.seen.send(Seen::Metrics(SeenUpdate {
                             has_schema,
-                            decoded_items,
-                        });
+                            decoded_items: decoder.iter().count(),
+                        }));
                         tx.send(Ok(())).await?;
                     }
                     _ => {
@@ -1211,27 +1238,29 @@ mod tests {
         }
     }
 
-    /// A reconnect must make the next metrics update carry the schema.
+    impl ProtocolHandler for TestServer {
+        async fn accept(&self, connection: Connection) -> Result<(), AcceptError> {
+            self.handle_connection(connection).await.map_err(|e| {
+                let boxed: Box<dyn std::error::Error + Send + Sync> = e.into();
+                AcceptError::from(AnyError::from(boxed))
+            })
+        }
+    }
+
+    /// Spawns `server` on its own endpoint and returns a client builder aimed
+    /// at it, with the router and the client endpoint for teardown.
     ///
-    /// The server holds one decoder per connection, so the first update after
-    /// a re-auth is undecodable unless the schema comes along again.
-    #[tokio::test]
-    async fn test_metrics_schema_resent_after_reconnect() {
-        let mut rng = rand::rngs::ChaCha8Rng::seed_from_u64(2);
+    /// The metrics interval is left to the caller, since that is what the
+    /// tests vary. The test server accepts any capability, so a self-issued
+    /// token works.
+    async fn spawn_test_server(seed: u64, server: TestServer) -> (Router, Endpoint, ClientBuilder) {
+        let mut rng = rand::rngs::ChaCha8Rng::seed_from_u64(seed);
         let server_ep = Endpoint::builder(presets::Minimal).bind().await.unwrap();
         let client_ep = Endpoint::builder(presets::Minimal).bind().await.unwrap();
-
-        let (seen_tx, mut seen_rx) = tokio::sync::mpsc::unbounded_channel();
-        let drop_next = Arc::new(AtomicBool::new(false));
-        let server = RecordingServer {
-            seen: seen_tx,
-            drop_next: drop_next.clone(),
-        };
         let router = Router::builder(server_ep.clone())
             .accept(ALPN, server)
             .spawn();
 
-        // The test server accepts any capability, so a self-issued token works.
         let shared_secret = SecretKey::from_bytes(&rng.random());
         let cap = create_api_token_from_secret_key(
             shared_secret,
@@ -1241,18 +1270,46 @@ mod tests {
         )
         .unwrap();
 
-        let client = Client::builder(&client_ep)
-            .disable_metrics_interval()
+        let builder = Client::builder(&client_ep)
             .remote(server_ep.addr())
             .rcan(cap)
-            .unwrap()
-            .build()
-            .await
             .unwrap();
+        (router, client_ep, builder)
+    }
+
+    /// Awaits the next metrics push the server recorded.
+    async fn next_metrics(rx: &mut tokio::sync::mpsc::UnboundedReceiver<Seen>) -> SeenUpdate {
+        match rx.recv().await.expect("server dropped the record channel") {
+            Seen::Metrics(update) => update,
+            other => panic!("expected a metrics push, recorded {other:?}"),
+        }
+    }
+
+    /// Takes everything the server has recorded so far, without waiting.
+    fn recorded_so_far(rx: &mut tokio::sync::mpsc::UnboundedReceiver<Seen>) -> Vec<Seen> {
+        let mut seen = Vec::new();
+        while let Ok(record) = rx.try_recv() {
+            seen.push(record);
+        }
+        seen
+    }
+
+    /// A reconnect must make the next metrics update carry the schema.
+    ///
+    /// The server holds one decoder per connection, so the first update after
+    /// a re-auth is undecodable unless the schema comes along again.
+    #[tokio::test]
+    async fn test_metrics_schema_resent_after_reconnect() {
+        let (seen_tx, mut seen_rx) = tokio::sync::mpsc::unbounded_channel();
+        let server = TestServer::new(seen_tx);
+        let drop_next = server.drop_next.clone();
+        let (router, client_ep, builder) = spawn_test_server(2, server).await;
+
+        let client = builder.disable_metrics_interval().build().await.unwrap();
 
         // The first export on a fresh session carries the schema.
         client.push_metrics().await.unwrap();
-        let first = seen_rx.recv().await.unwrap();
+        let first = next_metrics(&mut seen_rx).await;
         assert!(first.has_schema);
         assert!(first.decoded_items > 0);
 
@@ -1263,7 +1320,7 @@ mod tests {
         let mut settled = false;
         for _ in 0..20 {
             client.push_metrics().await.unwrap();
-            let seen = seen_rx.recv().await.unwrap();
+            let seen = next_metrics(&mut seen_rx).await;
             assert!(seen.decoded_items > 0);
             if !seen.has_schema {
                 settled = true;
@@ -1279,7 +1336,7 @@ mod tests {
         // The client re-dials and re-auths; the first update on the new
         // connection must include the schema for the server's fresh decoder.
         client.push_metrics().await.unwrap();
-        let third = seen_rx.recv().await.unwrap();
+        let third = next_metrics(&mut seen_rx).await;
         assert!(third.has_schema, "schema must be re-sent after a reconnect");
         assert!(third.decoded_items > 0);
 
@@ -1399,77 +1456,21 @@ mod tests {
     /// schema resend and then hit the same limit again.
     #[test]
     fn test_oversized_message_keeps_the_connection() {
-        let oversized = irpc::Error::Send {
-            source: irpc::channel::SendError::MaxMessageSizeExceeded {
-                meta: Default::default(),
-            },
+        let send_error = |source| irpc::Error::Send {
+            source,
             meta: Default::default(),
         };
-        assert!(!is_connection_lost(&oversized));
 
-        let closed = irpc::Error::Send {
-            source: irpc::channel::SendError::ReceiverClosed {
+        assert!(!is_connection_lost(&send_error(
+            irpc::channel::SendError::MaxMessageSizeExceeded {
                 meta: Default::default(),
-            },
-            meta: Default::default(),
-        };
-        assert!(is_connection_lost(&closed));
-    }
-
-    /// Mirrors the backend's request loop: reads are sequential and any error
-    /// ends the loop and the connection with it.
-    #[derive(Debug)]
-    struct SlowServer {
-        /// Set once the server has answered a Ping without the stream failing.
-        ping_answered: Arc<AtomicBool>,
-        /// Counts metrics pushes the server actually read.
-        metrics_seen: Arc<std::sync::atomic::AtomicUsize>,
-    }
-
-    impl ProtocolHandler for SlowServer {
-        async fn accept(&self, connection: Connection) -> Result<(), AcceptError> {
-            self.handle(connection).await.map_err(|e| {
-                let boxed: Box<dyn std::error::Error + Send + Sync> = e.into();
-                AcceptError::from(AnyError::from(boxed))
-            })
-        }
-    }
-
-    impl SlowServer {
-        async fn handle(&self, connection: Connection) -> anyhow::Result<()> {
-            let Some(first) = read_request::<IrohServicesProtocol>(&connection).await? else {
-                return Ok(());
-            };
-            let ServicesMessage::Auth(WithChannels { tx, .. }) = first else {
-                anyhow::bail!("expected auth first");
-            };
-            tx.send(()).await?;
-
-            loop {
-                let Ok(Some(request)) = read_request::<IrohServicesProtocol>(&connection).await
-                else {
-                    return Ok(());
-                };
-                match request {
-                    ServicesMessage::Ping(WithChannels { inner, tx, .. }) => {
-                        // long enough for shutdown to land while this is in flight
-                        n0_future::time::sleep(Duration::from_millis(300)).await;
-                        // a client that dropped the request resets the stream,
-                        // and this send is where the server finds out
-                        tx.send(Pong {
-                            req_id: inner.req_id,
-                        })
-                        .await?;
-                        self.ping_answered.store(true, Ordering::SeqCst);
-                    }
-                    ServicesMessage::PutMetrics(WithChannels { tx, .. }) => {
-                        self.metrics_seen.fetch_add(1, Ordering::SeqCst);
-                        tx.send(Ok(())).await?;
-                    }
-                    _ => anyhow::bail!("unexpected request"),
-                }
             }
-        }
+        )));
+        assert!(is_connection_lost(&send_error(
+            irpc::channel::SendError::ReceiverClosed {
+                meta: Default::default(),
+            }
+        )));
     }
 
     /// Assert that shutting down with a request in flight lets that request
@@ -1480,45 +1481,23 @@ mod tests {
     /// that shutdown exists for is never seen.
     #[tokio::test]
     async fn test_shutdown_drains_request_in_flight() {
-        let mut rng = rand::rngs::ChaCha8Rng::seed_from_u64(9);
-        let server_ep = Endpoint::builder(presets::Minimal).bind().await.unwrap();
-        let client_ep = Endpoint::builder(presets::Minimal).bind().await.unwrap();
-
-        let ping_answered = Arc::new(AtomicBool::new(false));
-        let metrics_seen = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let router = Router::builder(server_ep.clone())
-            .accept(
-                ALPN,
-                SlowServer {
-                    ping_answered: ping_answered.clone(),
-                    metrics_seen: metrics_seen.clone(),
-                },
-            )
-            .spawn();
-
-        let shared_secret = SecretKey::from_bytes(&rng.random());
-        let cap = create_api_token_from_secret_key(
-            shared_secret,
-            client_ep.id(),
-            Duration::from_secs(3600),
-            Caps::for_shared_secret(),
+        let (seen_tx, mut seen_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (router, client_ep, builder) = spawn_test_server(
+            9,
+            // long enough for shutdown to land while a ping is in flight
+            TestServer::new(seen_tx).ping_delay(Duration::from_millis(300)),
         )
-        .unwrap();
+        .await;
 
-        let client = Client::builder(&client_ep)
-            .rcan(cap)
-            .unwrap()
-            .remote(server_ep.addr())
+        let client = builder
             // long enough that only the startup tick fires on its own
             .metrics_interval(Duration::from_secs(3600))
             .build()
             .await
             .unwrap();
 
-        // let the startup metrics push establish the connection
-        n0_future::time::sleep(Duration::from_millis(500)).await;
-        let after_startup = metrics_seen.load(Ordering::SeqCst);
-        assert_eq!(after_startup, 1, "expected the startup metrics push");
+        // the startup push is what establishes the connection
+        next_metrics(&mut seen_rx).await;
 
         // put a ping in flight, then shut down while the server sits on it
         let pinging = client.clone();
@@ -1526,18 +1505,21 @@ mod tests {
         n0_future::time::sleep(Duration::from_millis(100)).await;
         client.shutdown().await;
 
+        let recorded = recorded_so_far(&mut seen_rx);
         assert!(
-            ping_answered.load(Ordering::SeqCst),
+            recorded
+                .iter()
+                .any(|seen| matches!(seen, Seen::PingAnswered)),
             "the ping in flight was dropped, so the server saw its stream fail"
         );
-        assert_eq!(
-            metrics_seen.load(Ordering::SeqCst),
-            after_startup + 1,
+        assert!(
+            recorded.iter().any(|seen| matches!(seen, Seen::Metrics(_))),
             "the final metrics push did not reach the server"
         );
 
         let _ = ping.await;
         router.shutdown().await.unwrap();
+        client_ep.close().await;
     }
 
     /// Assert that shutdown does not wait for a request in flight.

--- a/src/client.rs
+++ b/src/client.rs
@@ -641,6 +641,23 @@ enum ClientActorMessage {
     },
 }
 
+/// Whether an rpc error means the connection can no longer carry requests.
+///
+/// Most of these are the stream pair or the connection itself failing, so the
+/// connection has to go. An oversized message is the exception: irpc rejects it
+/// locally before anything reaches the wire, so the connection is still fine.
+/// Re-dialing on it would pay for a handshake and a full metrics schema resend
+/// only to hit the same limit on the retry.
+fn is_connection_lost(err: &irpc::Error) -> bool {
+    !matches!(
+        err,
+        irpc::Error::Send {
+            source: irpc::channel::SendError::MaxMessageSizeExceeded { .. },
+            ..
+        }
+    )
+}
+
 /// An irpc client bound to a single authenticated connection.
 ///
 /// The server accepts requests only after an `Auth` as the very first
@@ -917,11 +934,12 @@ impl ClientActor {
         trace!(request = %msg, "client actor send request");
         let client = self.connect().await?;
         let res = client.rpc(msg).await;
-        if res.is_err() {
-            // A transport-level failure means the connection is gone or in an
-            // unknown state; the next request dials and authenticates afresh.
-            // Server-side errors arrive as `Ok(Err(RemoteError))` and keep the
-            // connection.
+        if let Err(err) = &res
+            && is_connection_lost(err)
+        {
+            // The connection is gone or in an unknown state; the next request
+            // dials and authenticates afresh. Server-side errors arrive as
+            // `Ok(Err(RemoteError))` and keep the connection.
             self.client = None;
         }
         res.inspect_err(|err| warn!("rpc error: {err}"))
@@ -1092,7 +1110,7 @@ mod tests {
         client::{
             API_SECRET_ENV_VAR_NAME, BuildError, CLIENT_ATTRIBUTE_VALUE_MAX_LENGTH,
             CLIENT_ATTRIBUTES_MAX_COUNT, CLIENT_NAME_MAX_LENGTH, Error, ValidateAttributesError,
-            ValidateNameError,
+            ValidateNameError, is_connection_lost,
         },
         protocol::{ALPN, IrohServicesProtocol, ServicesMessage},
     };
@@ -1352,6 +1370,28 @@ mod tests {
         // the actor is gone, so requests fail
         let err = client.push_metrics().await;
         assert!(err.is_err());
+    }
+
+    /// An oversized message never reaches the wire, so it must not cost the
+    /// connection: re-dialing would pay for a handshake and a full metrics
+    /// schema resend and then hit the same limit again.
+    #[test]
+    fn test_oversized_message_keeps_the_connection() {
+        let oversized = irpc::Error::Send {
+            source: irpc::channel::SendError::MaxMessageSizeExceeded {
+                meta: Default::default(),
+            },
+            meta: Default::default(),
+        };
+        assert!(!is_connection_lost(&oversized));
+
+        let closed = irpc::Error::Send {
+            source: irpc::channel::SendError::ReceiverClosed {
+                meta: Default::default(),
+            },
+            meta: Default::default(),
+        };
+        assert!(is_connection_lost(&closed));
     }
 
     /// Assert that shutdown does not wait for a request in flight.

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,10 @@ use iroh_metrics::{MetricsGroup, Registry, encoding::Encoder};
 use irpc::{Channels, RpcMessage, WithChannels, channel::none::NoReceiver};
 use irpc_iroh::IrohRemoteConnection;
 use n0_error::StackResultExt;
-use n0_future::{task::AbortOnDropHandle, time::Duration};
+use n0_future::{
+    task::{self, AbortOnDropHandle},
+    time::{self, Duration},
+};
 use rcan::Rcan;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
@@ -267,7 +270,7 @@ impl ClientBuilder {
         let registry = Arc::new(RwLock::new(self.registry));
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         let shutdown = CancellationToken::new();
-        let actor_task = AbortOnDropHandle::new(n0_future::task::spawn(
+        let actor_task = AbortOnDropHandle::new(task::spawn(
             ClientActor {
                 capabilities,
                 endpoint: self.endpoint.clone(),
@@ -736,7 +739,7 @@ impl ClientActor {
         let metrics_enabled = interval.is_some();
         let shutdown_and_grace_period_expired = async {
             shutdown.cancelled().await;
-            n0_future::time::sleep(SHUTDOWN_GRACE).await;
+            time::sleep(SHUTDOWN_GRACE).await;
         };
 
         let clean_shutdown = tokio::select! {
@@ -751,7 +754,7 @@ impl ClientActor {
         // reintroduce the stall that cancelling just avoided, and an endpoint
         // that never connected has nothing the server could attribute.
         if clean_shutdown && metrics_enabled && self.is_connected() {
-            match n0_future::time::timeout(SHUTDOWN_FLUSH_TIMEOUT, self.send_metrics()).await {
+            match time::timeout(SHUTDOWN_FLUSH_TIMEOUT, self.send_metrics()).await {
                 Ok(Ok(())) => trace!("pushed final metrics on shutdown"),
                 Ok(Err(err)) => debug!(%err, "failed to push final metrics on shutdown"),
                 Err(_) => debug!("final metrics push on shutdown timed out"),
@@ -766,7 +769,7 @@ impl ClientActor {
         inbox: &mut tokio::sync::mpsc::Receiver<ClientActorMessage>,
         shutdown: &CancellationToken,
     ) {
-        let mut metrics_timer = interval.map(|interval| n0_future::time::interval(interval));
+        let mut metrics_timer = interval.map(|interval| time::interval(interval));
         trace!("starting client actor");
 
         // Send the initial metadata (set via the builder) once the actor starts.
@@ -793,8 +796,8 @@ impl ClientActor {
             trace!("client actor tick");
             tokio::select! {
                 biased;
-                // Only reached between requests: while an arm below is awaiting,
-                // this select is not polled, so the request finishes first.
+                // Shutdown is only observed between requests: a branch body below
+                // runs to completion, so a request already in flight finishes first.
                 () = shutdown.cancelled() => {
                     trace!("client actor observed shutdown between requests");
                     break;
@@ -1121,7 +1124,10 @@ mod tests {
     use irpc::WithChannels;
     use irpc_iroh::read_request;
     use n0_error::AnyError;
-    use n0_future::time::Duration;
+    use n0_future::{
+        task,
+        time::{self, Duration},
+    };
     use rand::{RngExt, SeedableRng};
     use temp_env_vars::temp_env_vars;
 
@@ -1211,7 +1217,7 @@ mod tests {
                         anyhow::bail!("client re-sent auth on a live connection");
                     }
                     ServicesMessage::Ping(WithChannels { inner, tx, .. }) => {
-                        n0_future::time::sleep(self.ping_delay).await;
+                        time::sleep(self.ping_delay).await;
                         // A client that dropped this request has reset the
                         // stream, and this send is where the server finds out.
                         tx.send(Pong {
@@ -1501,8 +1507,8 @@ mod tests {
 
         // put a ping in flight, then shut down while the server sits on it
         let pinging = client.clone();
-        let ping = n0_future::task::spawn(async move { pinging.ping().await });
-        n0_future::time::sleep(Duration::from_millis(100)).await;
+        let ping = task::spawn(async move { pinging.ping().await });
+        time::sleep(Duration::from_millis(100)).await;
         client.shutdown().await;
 
         let recorded = recorded_so_far(&mut seen_rx);
@@ -1550,9 +1556,9 @@ mod tests {
             .unwrap();
 
         // let the startup metrics tick get as far as the dial
-        n0_future::time::sleep(Duration::from_millis(200)).await;
+        time::sleep(Duration::from_millis(200)).await;
 
-        n0_future::time::timeout(Duration::from_secs(5), client.shutdown())
+        time::timeout(Duration::from_secs(5), client.shutdown())
             .await
             .expect("shutdown blocked on the dial in flight");
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,6 +17,7 @@ use n0_error::StackResultExt;
 use n0_future::{task::AbortOnDropHandle, time::Duration};
 use rcan::Rcan;
 use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, trace, warn};
 use uuid::Uuid;
 
@@ -59,6 +60,8 @@ pub struct Client {
     #[allow(dead_code)]
     endpoint: Endpoint,
     message_channel: tokio::sync::mpsc::Sender<ClientActorMessage>,
+    /// Cancelled by [`Client::shutdown`] to stop whatever the actor is doing.
+    shutdown: CancellationToken,
     _actor_task: Arc<AbortOnDropHandle<()>>,
 }
 
@@ -263,6 +266,7 @@ impl ClientBuilder {
 
         let registry = Arc::new(RwLock::new(self.registry));
         let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let shutdown = CancellationToken::new();
         let actor_task = AbortOnDropHandle::new(n0_future::task::spawn(
             ClientActor {
                 capabilities,
@@ -276,12 +280,13 @@ impl ClientBuilder {
                 encoder: Encoder::new(registry.clone()),
                 registry,
             }
-            .run(self.metrics_interval, rx),
+            .run(self.metrics_interval, rx, shutdown.clone()),
         ));
 
         Ok(Client {
             endpoint: self.endpoint,
             message_channel: tx,
+            shutdown,
             _actor_task: Arc::new(actor_task),
         })
     }
@@ -325,6 +330,13 @@ impl From<irpc::Error> for BuildError {
         }
     }
 }
+
+/// How long [`Client::shutdown`] waits for the final metrics push.
+///
+/// The push goes over an established connection, so it is normally well under
+/// this. The bound covers a peer that has gone silent without closing, where
+/// the request would otherwise hang until the connection times out.
+const SHUTDOWN_FLUSH_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Minimum length in bytes for an endpoint name.
 pub const CLIENT_NAME_MIN_LENGTH: usize = 2;
@@ -516,25 +528,20 @@ impl Client {
 
     /// Shuts down the client, pushing one final round of metrics first.
     ///
-    /// The final push only happens when the metrics interval is enabled, and
-    /// is best effort: push errors are logged and ignored. After this returns
-    /// the background actor has stopped, so requests on any clone of this
-    /// client will fail. Dropping the client without calling this aborts the
-    /// actor immediately, losing any metrics accumulated since the last
-    /// interval push.
+    /// Returns once the background actor has stopped, so requests on any clone
+    /// of this client will fail afterwards. Dropping the client without calling
+    /// this aborts the actor immediately, losing any metrics accumulated since
+    /// the last interval push.
+    ///
+    /// Any request in flight is cancelled rather than awaited, so a client that
+    /// cannot reach the server shuts down promptly instead of inheriting that
+    /// request's timeout. The final push is best effort: it happens only when
+    /// the metrics interval is enabled and a connection is already established,
+    /// gets a few seconds to complete, and errors are logged and ignored.
     pub async fn shutdown(&self) {
-        let (tx, rx) = oneshot::channel();
-        if self
-            .message_channel
-            .send(ClientActorMessage::Shutdown { done: tx })
-            .await
-            .is_err()
-        {
-            trace!("Shutdown called but actor already stopped");
-            // actor already stopped
-            return;
-        }
-        let _ = rx.await;
+        self.shutdown.cancel();
+        // The actor drops the inbox receiver on its way out.
+        self.message_channel.closed().await;
     }
 
     /// Grant capabilities to a remote endpoint. Creates a signed RCAN token
@@ -632,9 +639,6 @@ enum ClientActorMessage {
         // known, and can fail with a local `InvalidAttributes` error.
         done: oneshot::Sender<Result<(), Error>>,
     },
-    Shutdown {
-        done: oneshot::Sender<()>,
-    },
 }
 
 /// An irpc client bound to a single authenticated connection.
@@ -693,10 +697,42 @@ struct ClientActor {
 }
 
 impl ClientActor {
+    /// Runs the actor until the inbox closes or `shutdown` is cancelled, then
+    /// pushes one final round of metrics.
+    ///
+    /// Cancellation drops whatever [`Self::run_inner`] is awaiting, so a
+    /// request in flight, most importantly a dial to a server that never
+    /// answers, does not hold up the shutdown.
     async fn run(
         mut self,
         interval: Option<Duration>,
         mut inbox: tokio::sync::mpsc::Receiver<ClientActorMessage>,
+        shutdown: CancellationToken,
+    ) {
+        let metrics_enabled = interval.is_some();
+        tokio::select! {
+            biased;
+            () = shutdown.cancelled() => trace!("client actor cancelled"),
+            () = self.run_inner(interval, &mut inbox) => {},
+        }
+
+        // Flush only over a connection that already exists. Dialing here would
+        // reintroduce the stall that cancelling just avoided, and an endpoint
+        // that never connected has nothing the server could attribute.
+        if metrics_enabled && self.is_connected() {
+            match n0_future::time::timeout(SHUTDOWN_FLUSH_TIMEOUT, self.send_metrics()).await {
+                Ok(Ok(())) => trace!("pushed final metrics on shutdown"),
+                Ok(Err(err)) => debug!(%err, "failed to push final metrics on shutdown"),
+                Err(_) => debug!("final metrics push on shutdown timed out"),
+            }
+        }
+        debug!("client actor shut down");
+    }
+
+    async fn run_inner(
+        &mut self,
+        interval: Option<Duration>,
+        inbox: &mut tokio::sync::mpsc::Receiver<ClientActorMessage>,
     ) {
         let mut metrics_timer = interval.map(|interval| n0_future::time::interval(interval));
         trace!("starting client actor");
@@ -797,15 +833,6 @@ impl ClientActor {
                                 warn!("failed to publish network diagnostics: {:#?}", err);
                             }
                         }
-                        ClientActorMessage::Shutdown { done } => {
-                            if metrics_timer.is_some()
-                                && let Err(err) = self.send_metrics().await
-                            {
-                                debug!("failed to push final metrics on shutdown: {:#?}", err);
-                            }
-                            let _ = done.send(());
-                            break;
-                        }
                     }
                 }
                 _ = async {
@@ -822,7 +849,16 @@ impl ClientActor {
                 },
             }
         }
-        debug!("client actor shut down");
+    }
+
+    /// Whether a connection is established and still usable.
+    ///
+    /// Distinct from holding a [`RpcClient`]: the remote may have closed the
+    /// connection since, in which case sending over it would have to re-dial.
+    fn is_connected(&self) -> bool {
+        self.client
+            .as_ref()
+            .is_some_and(|client| client.connection.close_reason().is_none())
     }
 
     /// Returns the client for the active connection, establishing one if needed.
@@ -1302,6 +1338,41 @@ mod tests {
         // the actor is gone, so requests fail
         let err = client.push_metrics().await;
         assert!(err.is_err());
+    }
+
+    /// Assert that shutdown does not wait for a request in flight.
+    ///
+    /// The metrics interval fires as soon as the actor starts, so with an
+    /// unreachable remote the actor is inside a dial that runs for about a
+    /// minute. Shutting down has to cancel that dial rather than queue behind
+    /// it.
+    #[tokio::test]
+    async fn test_shutdown_cancels_dial_in_flight() {
+        let mut rng = rand::rngs::ChaCha8Rng::seed_from_u64(3);
+        let shared_secret = SecretKey::from_bytes(&rng.random());
+        let fake_endpoint_id = SecretKey::from_bytes(&rng.random()).public();
+        let api_secret = ApiSecret::new(shared_secret, fake_endpoint_id);
+
+        let endpoint = Endpoint::builder(presets::Minimal).bind().await.unwrap();
+
+        let client = Client::builder(&endpoint)
+            .api_secret(api_secret)
+            .unwrap()
+            // TEST-NET-1, routable but silently dropped, so the dial hangs
+            // instead of failing fast the way an address-less remote would.
+            .remote(
+                EndpointAddr::new(fake_endpoint_id).with_ip_addr("192.0.2.1:1234".parse().unwrap()),
+            )
+            .build()
+            .await
+            .unwrap();
+
+        // let the startup metrics tick get as far as the dial
+        n0_future::time::sleep(Duration::from_millis(200)).await;
+
+        n0_future::time::timeout(Duration::from_secs(5), client.shutdown())
+            .await
+            .expect("shutdown blocked on the dial in flight");
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -875,18 +875,25 @@ impl ClientActor {
             debug!(%reason, "connection closed by remote, reconnecting");
             self.client = None;
         }
-        if self.client.is_none() {
-            let client = RpcClient::connect(
-                &self.endpoint,
-                self.remote.clone(),
-                self.capabilities.clone(),
-            )
-            .await?;
-            // Recreate the metrics encoder to force sending the schema on the next metrics push.
-            self.encoder = Encoder::new(self.registry.clone());
-            self.client = Some(client);
-        }
-        Ok(&self.client.as_ref().expect("just checked").irpc)
+        // Taking the connection out and putting it back lets `insert` hand out
+        // a borrow tied to the value it just stored. Checking `is_none` and
+        // then looking the value up again needs an `expect`, because the
+        // compiler cannot see that the lookup follows the store.
+        let client = match self.client.take() {
+            Some(client) => client,
+            None => {
+                let client = RpcClient::connect(
+                    &self.endpoint,
+                    self.remote.clone(),
+                    self.capabilities.clone(),
+                )
+                .await?;
+                // Recreate the metrics encoder to force sending the schema on the next metrics push.
+                self.encoder = Encoder::new(self.registry.clone());
+                client
+            }
+        };
+        Ok(&self.client.insert(client).irpc)
     }
 
     async fn rpc<Req, Res>(&mut self, msg: Req) -> Result<Res, Error>

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,6 +7,7 @@ use std::{
 use anyhow::{Result, anyhow, ensure};
 use iroh::{Endpoint, EndpointAddr, EndpointId, endpoint::ConnectError};
 use iroh_metrics::{MetricsGroup, Registry, encoding::Encoder};
+use irpc::{Channels, RpcMessage, WithChannels, channel::none::NoReceiver};
 use irpc_iroh::IrohLazyRemoteConnection;
 use n0_error::StackResultExt;
 use n0_future::{task::AbortOnDropHandle, time::Duration};
@@ -20,8 +21,8 @@ use crate::{
     caps::{Caps, DEFAULT_CAP_EXPIRY},
     net_diagnostics::{DiagnosticsReport, checks::run_diagnostics},
     protocol::{
-        ALPN, Auth, IrohServicesClient, NameEndpoint, Ping, Pong, PutMetrics,
-        PutNetworkDiagnostics, RemoteError, SetAttributes, SetGroup,
+        ALPN, Auth, IrohServicesClient, IrohServicesProtocol, NameEndpoint, Ping, Pong, PutMetrics,
+        PutNetworkDiagnostics, RemoteError, ServicesMessage, SetAttributes, SetGroup,
     },
 };
 
@@ -641,7 +642,7 @@ struct ClientActor {
     session_id: Uuid,
     authorized: bool,
     encoder: Encoder,
-    // Kept so auth() can rebuild the encoder; a fresh encoder re-sends the schema.
+    /// Kept so auth() can rebuild the encoder to re-send the metrics schema.
     registry: Arc<RwLock<Registry>>,
 }
 
@@ -804,52 +805,45 @@ impl ClientActor {
         Ok(())
     }
 
-    /// Marks the session unauthorized when an rpc fails.
-    ///
-    /// The lazy connection re-dials on the next request, and the server
-    /// accepts only Auth first on a new connection, so the next call must run
-    /// the handshake again (which also re-sends the metrics schema).
-    fn track_rpc<T>(&mut self, res: Result<T, irpc::Error>) -> Result<T, irpc::Error> {
+    async fn rpc<Req, Res>(&mut self, msg: Req) -> Result<Res, RemoteError>
+    where
+        IrohServicesProtocol: From<Req>,
+        ServicesMessage: From<WithChannels<Req, IrohServicesProtocol>>,
+        Req: Channels<
+                IrohServicesProtocol,
+                Tx = irpc::channel::oneshot::Sender<Res>,
+                Rx = NoReceiver,
+            >,
+        Res: RpcMessage,
+    {
+        self.auth().await?;
+        let res = self.client.rpc(msg).await;
         if res.is_err() {
             self.authorized = false;
         }
-        res
+        res.inspect_err(|e| warn!("rpc error: {e}"))
+            .map_err(|_| RemoteError::InternalServerError)
     }
 
     async fn send_ping(&mut self) -> Result<Pong, RemoteError> {
         trace!("client actor send ping");
-        self.auth().await?;
-
         let req = rand::random();
-        let res = self.client.rpc(Ping { req_id: req }).await;
-        self.track_rpc(res)
-            .inspect_err(|e| warn!("rpc ping error: {e}"))
-            .map_err(|_| RemoteError::InternalServerError)
+        self.rpc(Ping { req_id: req }).await
     }
 
     async fn send_name_endpoint(&mut self, name: String) -> Result<(), RemoteError> {
         trace!("client sending name endpoint request");
-        self.auth().await?;
-
-        let res = self.client.rpc(NameEndpoint { name: name.clone() }).await;
-        self.track_rpc(res)
-            .inspect_err(|e| debug!("name endpoint error: {e}"))
-            .map_err(|_| RemoteError::InternalServerError)??;
+        self.rpc(NameEndpoint { name: name.clone() }).await??;
         self.name = Some(name);
         Ok(())
     }
 
     async fn send_set_group(&mut self, group: String) -> Result<(), RemoteError> {
         trace!("client sending set group request");
-        self.auth().await?;
-
-        self.client
-            .rpc(SetGroup {
-                group: group.clone(),
-            })
-            .await
-            .inspect_err(|e| debug!("set group error: {e}"))
-            .map_err(|_| RemoteError::InternalServerError)??;
+        self.rpc(SetGroup {
+            group: group.clone(),
+        })
+        .await??;
         self.group = Some(group);
         Ok(())
     }
@@ -859,45 +853,29 @@ impl ClientActor {
         attributes: BTreeMap<String, String>,
     ) -> Result<(), RemoteError> {
         trace!("client sending set attributes request");
-        self.auth().await?;
-
-        self.client
-            .rpc(SetAttributes {
-                attributes: attributes.clone(),
-            })
-            .await
-            .inspect_err(|e| debug!("set attributes error: {e}"))
-            .map_err(|_| RemoteError::InternalServerError)??;
+        self.rpc(SetAttributes {
+            attributes: attributes.clone(),
+        })
+        .await??;
         self.attributes = attributes;
         Ok(())
     }
 
     async fn send_metrics(&mut self) -> Result<(), RemoteError> {
         trace!("client actor send metrics");
-        self.auth().await?;
-
         let update = self.encoder.export();
         // let delta = update_delta(&self.latest_ackd_update, &update);
         let req = PutMetrics {
             session_id: self.session_id,
             update,
         };
-
-        let res = self.client.rpc(req).await;
-        self.track_rpc(res)
-            .map_err(|_| RemoteError::InternalServerError)??;
-
+        self.rpc(req).await??;
         Ok(())
     }
 
     async fn grant_cap(&mut self, cap: Rcan<Caps>) -> Result<(), Error> {
         trace!("client actor grant capability");
-        self.auth().await?;
-
-        let res = self.client.rpc(crate::protocol::GrantCap { cap }).await;
-        self.track_rpc(res)
-            .map_err(|_| RemoteError::InternalServerError)??;
-
+        self.rpc(crate::protocol::GrantCap { cap }).await??;
         Ok(())
     }
 
@@ -906,14 +884,8 @@ impl ClientActor {
         report: crate::net_diagnostics::DiagnosticsReport,
     ) -> Result<(), Error> {
         trace!("client actor publish network diagnostics");
-        self.auth().await?;
-
         let req = PutNetworkDiagnostics { report };
-
-        let res = self.client.rpc(req).await;
-        self.track_rpc(res)
-            .map_err(|_| RemoteError::InternalServerError)??;
-
+        self.rpc(req).await??;
         Ok(())
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -259,6 +259,7 @@ impl ClientBuilder {
         let conn = IrohLazyRemoteConnection::new(self.endpoint.clone(), remote, ALPN.to_vec());
         let irpc_client = IrohServicesClient::boxed(conn);
 
+        let registry = Arc::new(RwLock::new(self.registry));
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         let actor_task = AbortOnDropHandle::new(n0_future::task::spawn(
             ClientActor {
@@ -269,8 +270,10 @@ impl ClientBuilder {
                 attributes: self.attributes.clone().unwrap_or_default(),
                 session_id: Uuid::new_v4(),
                 authorized: false,
+                encoder: Encoder::new(registry.clone()),
+                registry,
             }
-            .run(self.registry, self.metrics_interval, rx),
+            .run(self.metrics_interval, rx),
         ));
 
         Ok(Client {
@@ -637,17 +640,17 @@ struct ClientActor {
     attributes: BTreeMap<String, String>,
     session_id: Uuid,
     authorized: bool,
+    encoder: Encoder,
+    // Kept so auth() can rebuild the encoder; a fresh encoder re-sends the schema.
+    registry: Arc<RwLock<Registry>>,
 }
 
 impl ClientActor {
     async fn run(
         mut self,
-        registry: Registry,
         interval: Option<Duration>,
         mut inbox: tokio::sync::mpsc::Receiver<ClientActorMessage>,
     ) {
-        let registry = Arc::new(RwLock::new(registry));
-        let mut encoder = Encoder::new(registry);
         let mut metrics_timer = interval.map(|interval| n0_future::time::interval(interval));
         trace!("starting client actor");
 
@@ -686,7 +689,7 @@ impl ClientActor {
                         },
                         ClientActorMessage::SendMetrics{ done } => {
                             trace!("sending metrics manually triggered");
-                            let res = self.send_metrics(&mut encoder).await;
+                            let res = self.send_metrics().await;
                             if let Err(err) = done.send(res) {
                                 debug!("failed to push metrics: {:#?}", err);
                                 self.authorized = false;
@@ -751,7 +754,7 @@ impl ClientActor {
                         }
                         ClientActorMessage::Shutdown { done } => {
                             if metrics_timer.is_some()
-                                && let Err(err) = self.send_metrics(&mut encoder).await
+                                && let Err(err) = self.send_metrics().await
                             {
                                 debug!("failed to push final metrics on shutdown: {:#?}", err);
                             }
@@ -768,7 +771,7 @@ impl ClientActor {
                     }
                 } => {
                     trace!("metrics send tick");
-                    if let Err(err) = self.send_metrics(&mut encoder).await {
+                    if let Err(err) = self.send_metrics().await {
                         debug!("failed to push metrics: {:#?}", err);
                         self.authorized = false;
                     }
@@ -792,7 +795,25 @@ impl ClientActor {
             .inspect_err(|e| debug!("authorization failed: {:?}", e))
             .map_err(|e| RemoteError::AuthError(e.to_string()))?;
         self.authorized = true;
+        // A completed handshake means a fresh connection, and the server keeps
+        // one metrics decoder per connection. A new encoder starts at schema
+        // version zero, so the next export carries the full schema for that
+        // decoder. Re-importing a schema is idempotent server-side, so
+        // re-sending after a spurious re-auth is harmless.
+        self.encoder = Encoder::new(self.registry.clone());
         Ok(())
+    }
+
+    /// Marks the session unauthorized when an rpc fails.
+    ///
+    /// The lazy connection re-dials on the next request, and the server
+    /// accepts only Auth first on a new connection, so the next call must run
+    /// the handshake again (which also re-sends the metrics schema).
+    fn track_rpc<T>(&mut self, res: Result<T, irpc::Error>) -> Result<T, irpc::Error> {
+        if res.is_err() {
+            self.authorized = false;
+        }
+        res
     }
 
     async fn send_ping(&mut self) -> Result<Pong, RemoteError> {
@@ -800,9 +821,8 @@ impl ClientActor {
         self.auth().await?;
 
         let req = rand::random();
-        self.client
-            .rpc(Ping { req_id: req })
-            .await
+        let res = self.client.rpc(Ping { req_id: req }).await;
+        self.track_rpc(res)
             .inspect_err(|e| warn!("rpc ping error: {e}"))
             .map_err(|_| RemoteError::InternalServerError)
     }
@@ -811,9 +831,8 @@ impl ClientActor {
         trace!("client sending name endpoint request");
         self.auth().await?;
 
-        self.client
-            .rpc(NameEndpoint { name: name.clone() })
-            .await
+        let res = self.client.rpc(NameEndpoint { name: name.clone() }).await;
+        self.track_rpc(res)
             .inspect_err(|e| debug!("name endpoint error: {e}"))
             .map_err(|_| RemoteError::InternalServerError)??;
         self.name = Some(name);
@@ -853,20 +872,19 @@ impl ClientActor {
         Ok(())
     }
 
-    async fn send_metrics(&mut self, encoder: &mut Encoder) -> Result<(), RemoteError> {
+    async fn send_metrics(&mut self) -> Result<(), RemoteError> {
         trace!("client actor send metrics");
         self.auth().await?;
 
-        let update = encoder.export();
+        let update = self.encoder.export();
         // let delta = update_delta(&self.latest_ackd_update, &update);
         let req = PutMetrics {
             session_id: self.session_id,
             update,
         };
 
-        self.client
-            .rpc(req)
-            .await
+        let res = self.client.rpc(req).await;
+        self.track_rpc(res)
             .map_err(|_| RemoteError::InternalServerError)??;
 
         Ok(())
@@ -876,9 +894,8 @@ impl ClientActor {
         trace!("client actor grant capability");
         self.auth().await?;
 
-        self.client
-            .rpc(crate::protocol::GrantCap { cap })
-            .await
+        let res = self.client.rpc(crate::protocol::GrantCap { cap }).await;
+        self.track_rpc(res)
             .map_err(|_| RemoteError::InternalServerError)??;
 
         Ok(())
@@ -893,9 +910,8 @@ impl ClientActor {
 
         let req = PutNetworkDiagnostics { report };
 
-        self.client
-            .rpc(req)
-            .await
+        let res = self.client.rpc(req).await;
+        self.track_rpc(res)
             .map_err(|_| RemoteError::InternalServerError)??;
 
         Ok(())
@@ -976,22 +992,204 @@ async fn set_attribute_inner(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{
+        collections::HashMap,
+        sync::{
+            Arc, RwLock,
+            atomic::{AtomicBool, Ordering},
+        },
+    };
 
-    use iroh::{Endpoint, EndpointAddr, SecretKey, endpoint::presets};
+    use iroh::{
+        Endpoint, EndpointAddr, SecretKey,
+        endpoint::{Connection, presets},
+        protocol::{AcceptError, ProtocolHandler, Router},
+    };
+    use iroh_metrics::{
+        Registry,
+        encoding::{Decoder, Encoder},
+    };
+    use irpc::WithChannels;
+    use irpc_iroh::read_request;
+    use n0_error::AnyError;
+    use n0_future::time::Duration;
     use rand::{RngExt, SeedableRng};
     use temp_env_vars::temp_env_vars;
 
     use crate::{
         Client,
         api_secret::ApiSecret,
-        caps::{Cap, Caps},
+        caps::{Cap, Caps, create_api_token_from_secret_key},
         client::{
             API_SECRET_ENV_VAR_NAME, BuildError, CLIENT_ATTRIBUTE_VALUE_MAX_LENGTH,
             CLIENT_ATTRIBUTES_MAX_COUNT, CLIENT_NAME_MAX_LENGTH, Error, ValidateAttributesError,
             ValidateNameError,
         },
+        protocol::{ALPN, IrohServicesProtocol, ServicesMessage},
     };
+
+    /// What the test server recorded about one PutMetrics request.
+    #[derive(Debug)]
+    struct SeenUpdate {
+        has_schema: bool,
+        decoded_items: usize,
+    }
+
+    /// In-process stand-in for the services backend.
+    ///
+    /// Mirrors the real server's session rules: the first request on every
+    /// connection must be Auth, and the metrics decoder lives per connection.
+    #[derive(Debug)]
+    struct RecordingServer {
+        seen: tokio::sync::mpsc::UnboundedSender<SeenUpdate>,
+        drop_next: Arc<AtomicBool>,
+    }
+
+    impl ProtocolHandler for RecordingServer {
+        async fn accept(&self, connection: Connection) -> Result<(), AcceptError> {
+            self.handle_connection(connection).await.map_err(|e| {
+                let boxed: Box<dyn std::error::Error + Send + Sync> = e.into();
+                AcceptError::from(AnyError::from(boxed))
+            })
+        }
+    }
+
+    impl RecordingServer {
+        async fn handle_connection(&self, connection: Connection) -> anyhow::Result<()> {
+            let mut decoder = Decoder::default();
+            let mut authed = false;
+            loop {
+                let Some(request) = read_request::<IrohServicesProtocol>(&connection).await? else {
+                    return Ok(());
+                };
+                if self.drop_next.swap(false, Ordering::SeqCst) {
+                    // Simulates a server restart: the connection dies without an
+                    // answer and takes the per-connection decoder with it.
+                    connection.close(500u32.into(), b"test restart");
+                    return Ok(());
+                }
+                match request {
+                    ServicesMessage::Auth(WithChannels { tx, .. }) => {
+                        authed = true;
+                        tx.send(()).await?;
+                    }
+                    ServicesMessage::PutMetrics(WithChannels { inner, tx, .. }) if authed => {
+                        let has_schema = inner.update.schema.is_some();
+                        decoder.import(inner.update);
+                        let decoded_items = decoder.iter().count();
+                        let _ = self.seen.send(SeenUpdate {
+                            has_schema,
+                            decoded_items,
+                        });
+                        tx.send(Ok(())).await?;
+                    }
+                    _ => {
+                        connection.close(400u32.into(), b"Expected initial auth message");
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+
+    /// A reconnect must make the next metrics update carry the schema.
+    ///
+    /// The server holds one decoder per connection, so the first update after
+    /// a re-auth is undecodable unless the schema comes along again.
+    #[tokio::test]
+    async fn test_metrics_schema_resent_after_reconnect() {
+        let mut rng = rand::rngs::ChaCha8Rng::seed_from_u64(2);
+        let server_ep = Endpoint::builder(presets::Minimal).bind().await.unwrap();
+        let client_ep = Endpoint::builder(presets::Minimal).bind().await.unwrap();
+
+        let (seen_tx, mut seen_rx) = tokio::sync::mpsc::unbounded_channel();
+        let drop_next = Arc::new(AtomicBool::new(false));
+        let server = RecordingServer {
+            seen: seen_tx,
+            drop_next: drop_next.clone(),
+        };
+        let router = Router::builder(server_ep.clone())
+            .accept(ALPN, server)
+            .spawn();
+
+        // The test server accepts any capability, so a self-issued token works.
+        let shared_secret = SecretKey::from_bytes(&rng.random());
+        let cap = create_api_token_from_secret_key(
+            shared_secret,
+            client_ep.id(),
+            Duration::from_secs(3600),
+            Caps::for_shared_secret(),
+        )
+        .unwrap();
+
+        let client = Client::builder(&client_ep)
+            .disable_metrics_interval()
+            .remote(server_ep.addr())
+            .rcan(cap)
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+
+        // The first export on a fresh session carries the schema.
+        client.push_metrics().await.unwrap();
+        let first = seen_rx.recv().await.unwrap();
+        assert!(first.has_schema);
+        assert!(first.decoded_items > 0);
+
+        // Steady state suppresses the schema; the connection's decoder
+        // already has it and keeps decoding.
+        client.push_metrics().await.unwrap();
+        let second = seen_rx.recv().await.unwrap();
+        assert!(!second.has_schema);
+        assert!(second.decoded_items > 0);
+
+        // The server drops the connection mid-request: one failed round trip.
+        drop_next.store(true, Ordering::SeqCst);
+        assert!(client.push_metrics().await.is_err());
+
+        // The client re-dials and re-auths; the first update on the new
+        // connection must include the schema for the server's fresh decoder.
+        client.push_metrics().await.unwrap();
+        let third = seen_rx.recv().await.unwrap();
+        assert!(third.has_schema, "schema must be re-sent after a reconnect");
+        assert!(third.decoded_items > 0);
+
+        router.shutdown().await.unwrap();
+        client_ep.close().await;
+    }
+
+    /// Documents the encoder and decoder contract the reconnect fix relies on.
+    #[tokio::test]
+    async fn test_fresh_encoder_resends_schema() {
+        let endpoint = Endpoint::builder(presets::Minimal).bind().await.unwrap();
+        let mut registry = Registry::default();
+        registry.register_all(endpoint.metrics());
+        let registry = Arc::new(RwLock::new(registry));
+
+        let mut encoder = Encoder::new(registry.clone());
+        let first = encoder.export();
+        assert!(first.schema.is_some());
+
+        // Steady state omits the schema once it has been exported.
+        let schemaless = encoder.export();
+        assert!(schemaless.schema.is_none());
+
+        // A decoder that never saw the schema decodes such an update to
+        // nothing: this is the server side of the reconnect bug.
+        let mut fresh_decoder = Decoder::default();
+        fresh_decoder.import(schemaless);
+        assert_eq!(fresh_decoder.iter().count(), 0);
+
+        // A new encoder over the same registry starts at schema version zero
+        // and re-publishes the schema, which is what auth() does on re-auth.
+        let mut encoder = Encoder::new(registry);
+        let resent = encoder.export();
+        assert!(resent.schema.is_some());
+        let mut fresh_decoder = Decoder::default();
+        fresh_decoder.import(resent);
+        assert!(fresh_decoder.iter().count() > 0);
+    }
 
     #[tokio::test]
     #[temp_env_vars]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,9 @@ pub use iroh_metrics::Registry;
 
 pub use self::{
     api_secret::{API_SECRET_ENV_VAR_NAME, ApiSecret},
-    client::{Client, ClientBuilder},
+    client::{
+        BuildError, Client, ClientBuilder, Error, ValidateAttributesError, ValidateNameError,
+    },
     net_diagnostics::{DiagnosticsReport, checks::run_diagnostics},
     preset::{IrohServicesPreset, PresetBuilder, preset},
     protocol::ALPN,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -95,20 +95,23 @@ pub enum RemoteError {
 }
 
 /// Authentication on first request
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, derive_more::Display, Serialize, Deserialize)]
+#[display("Auth")]
 pub struct Auth {
     pub caps: Rcan<Caps>,
 }
 
 /// Request to store the given metrics data
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, derive_more::Display, Serialize, Deserialize)]
+#[display("PutMetrics")]
 pub struct PutMetrics {
     pub session_id: Uuid,
     pub update: iroh_metrics::encoding::Update,
 }
 
 /// Simple ping requests
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, derive_more::Display, Serialize, Deserialize)]
+#[display("Ping")]
 pub struct Ping {
     pub req_id: [u8; 16],
 }
@@ -120,7 +123,8 @@ pub struct Pong {
 }
 
 /// Publishing network diagnostics
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, derive_more::Display, Serialize, Deserialize)]
+#[display("PutNetworkDiagnostics")]
 pub struct PutNetworkDiagnostics {
     pub report: crate::net_diagnostics::DiagnosticsReport,
 }
@@ -128,30 +132,35 @@ pub struct PutNetworkDiagnostics {
 /// ask this node to run diagnostics & return the result.
 /// present even without the net_diagnostics feature flag because the request
 /// struct is empty in both cases
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, derive_more::Display, Serialize, Deserialize)]
+#[display("RunNetworkDiagnostics")]
 pub struct RunNetworkDiagnostics;
 
 /// Grant a capability token to the remote endpoint. The remote should store
 /// the RCAN and use it when dialing back to authorize its requests.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, derive_more::Display, Serialize, Deserialize)]
+#[display("GrantCap")]
 pub struct GrantCap {
     pub cap: Rcan<Caps>,
 }
 
 /// Label the client endpoint cloud-side with a string identifier.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, derive_more::Display, Serialize, Deserialize)]
+#[display("NameEndpoint")]
 pub struct NameEndpoint {
     pub name: String,
 }
 
 /// Attach the client endpoint to a single named group cloud-side.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, derive_more::Display, Serialize, Deserialize)]
+#[display("SetGroup")]
 pub struct SetGroup {
     pub group: String,
 }
 
 /// Replace the arbitrary key-value attributes on the client endpoint cloud-side.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, derive_more::Display, Serialize, Deserialize)]
+#[display("SetAttributes")]
 pub struct SetAttributes {
     pub attributes: BTreeMap<String, String>,
 }


### PR DESCRIPTION
## Description

iroh-services kept the metrics encoder global per client. The metrics encoder sends the schema only once, then only value updates (on purpose, to save bandwidth). However this means it needs to be recreated if the irpc connection breaks and reconnects, because otherwise the new connection receives only values but not the initial schema.

This PR fixes this by making the client actor own the connection instead of using `IrohLazyRemoteConnection`. The lazy connection reconnects transparently inside a request, which breaks more than the encoder: the server requires `Auth` as the first request on every connection, so the request riding a transparent reconnect is unauthenticated and gets rejected. The actor now dials on demand, authenticates as the connection's first request, and recreates the encoder in the same step, so the first metrics push on a new connection carries the schema again. Metrics sends establish the connection before exporting, so the export always comes from the encoder that matches the connection. On a transport error the actor drops the connection and the next request re-dials and re-authenticates.

Without this fix, metrics were stopping to work whenever the connection to svc broke because svc would ignore metrics pushed on a connection where a schema was never included.

Comes with a test that fails without the fix. The test server mirrors the real backend's session rules: auth must be the first request on a connection, and a repeat auth closes it.

## Breaking Changes

`client::Error` gained a `Connect(iroh::endpoint::ConnectError)` variant, and `Error` and `BuildError` are now `#[non_exhaustive]`. The error mapping changed for callers inspecting variants:

- `Error::Connect`: added. Failing to dial the remote now surfaces as this variant instead of `Error::Remote(RemoteError::AuthError)`.
- `Error::Rpc`: transport failures during a request now surface as this variant instead of `Error::Remote(RemoteError::InternalServerError)`. Its display string changed from "Connection error" to "Rpc error".

`Error`, `BuildError`, `ValidateNameError`, and `ValidateAttributesError` are now re-exported from the crate root; previously they were returned by public methods but not nameable outside the crate.

The wire protocol is unchanged; `RemoteError` keeps its v1 layout.

## Notes & open questions

- A request that hits a dead connection still fails once; the reconnect happens on the next request. Making that transparent would need an auth hook in irpc-iroh's lazy connection, left as a follow-up.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
